### PR TITLE
More contenttypes

### DIFF
--- a/src/recensio/plone/content/presentation_article_review.py
+++ b/src/recensio/plone/content/presentation_article_review.py
@@ -1,0 +1,13 @@
+from plone.dexterity.content import Item
+from plone.supermodel import model
+from zope.interface import implementer
+
+
+class IPresentationArticleReview(model.Schema):
+    """Marker interface and Dexterity Python Schema for
+    PresentationArticleReview."""
+
+
+@implementer(IPresentationArticleReview)
+class PresentationArticleReview(Item):
+    """Content-type class for IPresentationArticleReview."""

--- a/src/recensio/plone/content/presentation_collection.py
+++ b/src/recensio/plone/content/presentation_collection.py
@@ -1,0 +1,13 @@
+from plone.dexterity.content import Item
+from plone.supermodel import model
+from zope.interface import implementer
+
+
+class IPresentationCollection(model.Schema):
+    """Marker interface and Dexterity Python Schema for
+    PresentationCollection."""
+
+
+@implementer(IPresentationCollection)
+class PresentationCollection(Item):
+    """Content-type class for IPresentationCollection."""

--- a/src/recensio/plone/content/presentation_monograph.py
+++ b/src/recensio/plone/content/presentation_monograph.py
@@ -1,0 +1,13 @@
+from plone.dexterity.content import Item
+from plone.supermodel import model
+from zope.interface import implementer
+
+
+class IPresentationMonograph(model.Schema):
+    """Marker interface and Dexterity Python Schema for
+    PresentationMonograph."""
+
+
+@implementer(IPresentationMonograph)
+class PresentationMonograph(Item):
+    """Content-type class for IPresentationMonograph."""

--- a/src/recensio/plone/content/presentation_online_resource.py
+++ b/src/recensio/plone/content/presentation_online_resource.py
@@ -1,0 +1,13 @@
+from plone.dexterity.content import Item
+from plone.supermodel import model
+from zope.interface import implementer
+
+
+class IPresentationOnlineResource(model.Schema):
+    """Marker interface and Dexterity Python Schema for
+    PresentationOnlineResource."""
+
+
+@implementer(IPresentationOnlineResource)
+class PresentationOnlineResource(Item):
+    """Content-type class for IPresentationOnlineResource."""

--- a/src/recensio/plone/content/review_exhibition.py
+++ b/src/recensio/plone/content/review_exhibition.py
@@ -1,0 +1,12 @@
+from plone.dexterity.content import Item
+from plone.supermodel import model
+from zope.interface import implementer
+
+
+class IReviewExhibition(model.Schema):
+    """Marker interface and Dexterity Python Schema for ReviewExhibition."""
+
+
+@implementer(IReviewExhibition)
+class ReviewExhibition(Item):
+    """Content-type class for IReviewExhibition."""

--- a/src/recensio/plone/profiles/default/types.xml
+++ b/src/recensio/plone/profiles/default/types.xml
@@ -3,7 +3,10 @@
         name="portal_types"
 >
   <object meta_type="Dexterity FTI"
-          name="Presentation Online Resource"
+          name="Issue"
+  />
+  <object meta_type="Dexterity FTI"
+          name="Person"
   />
   <object meta_type="Dexterity FTI"
           name="Presentation Article Review"
@@ -12,36 +15,33 @@
           name="Presentation Collection"
   />
   <object meta_type="Dexterity FTI"
-          name="Review Journal"
-  />
-  <object meta_type="Dexterity FTI"
-          name="Review Article Journal"
-  />
-  <object meta_type="Dexterity FTI"
-          name="Review Article Collection"
-  />
-  <object meta_type="Dexterity FTI"
-          name="Review Exhibition"
-  />
-  <object meta_type="Dexterity FTI"
           name="Presentation Monograph"
   />
   <object meta_type="Dexterity FTI"
-          name="Review Monograph"
+          name="Presentation Online Resource"
   />
   <object meta_type="Dexterity FTI"
           name="Publication"
   />
   <object meta_type="Dexterity FTI"
-          name="Volume"
+          name="Review Article Collection"
   />
   <object meta_type="Dexterity FTI"
-          name="Issue"
+          name="Review Article Journal"
+  />
+  <object meta_type="Dexterity FTI"
+          name="Review Exhibition"
+  />
+  <object meta_type="Dexterity FTI"
+          name="Review Journal"
+  />
+  <object meta_type="Dexterity FTI"
+          name="Review Monograph"
   />
   <object meta_type="Dexterity FTI"
           name="Topic"
   />
   <object meta_type="Dexterity FTI"
-          name="Person"
+          name="Volume"
   />
 </object>

--- a/src/recensio/plone/profiles/default/types/Presentation_Article_Review.xml
+++ b/src/recensio/plone/profiles/default/types/Presentation_Article_Review.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Dexterity FTI"
+        name="Presentation Article Review"
+        i18n:domain="plone"
+>
+
+  <!-- Basic properties -->
+  <property name="title"
+            i18n:translate=""
+  >Presentation Article in Journal</property>
+  <property name="description"
+            i18n:translate="description_presentation_article"
+  />
+
+  <property name="allow_discussion">False</property>
+  <property name="factory">Presentation Article Review</property>
+  <property name="icon_expr" />
+  <property name="link_target" />
+
+  <!-- Hierarchy control -->
+  <property name="global_allow">False</property>
+  <!-- Schema, class and security -->
+  <property name="add_permission">recensio.plone.AddPresentationArticleReview</property>
+  <property name="klass">recensio.plone.content.presentation_article_review.PresentationArticleReview</property>
+  <property name="model_file" />
+  <property name="model_source" />
+  <property name="schema">recensio.plone.content.presentation_article_review.IPresentationArticleReview</property>
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors"
+            purge="false"
+  >
+    <element value="plone.basic" />
+    <element value="plone.namefromtitle" />
+    <element value="plone.allowdiscussion" />
+    <element value="plone.excludefromnavigation" />
+    <element value="plone.shortname" />
+    <element value="plone.ownership" />
+    <element value="plone.publication" />
+    <element value="plone.categorization" />
+    <element value="plone.locking" />
+  </property>
+
+  <!-- View information -->
+  <property name="add_view_expr">string:${folder_url}/++add++Presentation Article Review</property>
+  <property name="default_view">view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="immediate_view">view</property>
+  <property name="view_methods">
+    <element value="view" />
+  </property>
+
+  <!-- Method aliases -->
+  <alias from="(Default)"
+         to="(dynamic view)"
+  />
+  <alias from="edit"
+         to="@@edit"
+  />
+  <alias from="sharing"
+         to="@@sharing"
+  />
+  <alias from="view"
+         to="(selected layout)"
+  />
+
+  <!-- Actions -->
+  <action action_id="view"
+          category="object"
+          condition_expr=""
+          title="View"
+          url_expr="string:${object_url}"
+          visible="True"
+          i18n:attributes="title"
+          i18n:domain="plone"
+  >
+    <permission value="View" />
+  </action>
+  <action action_id="edit"
+          category="object"
+          condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
+          title="Edit"
+          url_expr="string:${object_url}/edit"
+          visible="True"
+          i18n:attributes="title"
+          i18n:domain="plone"
+  >
+    <permission value="Modify portal content" />
+  </action>
+
+</object>

--- a/src/recensio/plone/profiles/default/types/Presentation_Collection.xml
+++ b/src/recensio/plone/profiles/default/types/Presentation_Collection.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Dexterity FTI"
+        name="Presentation Collection"
+        i18n:domain="plone"
+>
+
+  <!-- Basic properties -->
+  <property name="title"
+            i18n:translate=""
+  >Presentation Collection</property>
+  <property name="description"
+            i18n:translate="description_presentation_collection"
+  />
+
+  <property name="allow_discussion">False</property>
+  <property name="factory">Presentation Collection</property>
+  <property name="icon_expr" />
+  <property name="link_target" />
+
+  <!-- Hierarchy control -->
+  <property name="global_allow">False</property>
+  <!-- Schema, class and security -->
+  <property name="add_permission">recensio.plone.AddPresentationCollection</property>
+  <property name="klass">recensio.plone.content.presentation_collection.PresentationCollection</property>
+  <property name="model_file" />
+  <property name="model_source" />
+  <property name="schema">recensio.plone.content.presentation_collection.IPresentationCollection</property>
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors"
+            purge="false"
+  >
+    <element value="plone.basic" />
+    <element value="plone.namefromtitle" />
+    <element value="plone.allowdiscussion" />
+    <element value="plone.excludefromnavigation" />
+    <element value="plone.shortname" />
+    <element value="plone.ownership" />
+    <element value="plone.publication" />
+    <element value="plone.categorization" />
+    <element value="plone.locking" />
+  </property>
+
+  <!-- View information -->
+  <property name="add_view_expr">string:${folder_url}/++add++Presentation Collection</property>
+  <property name="default_view">view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="immediate_view">view</property>
+  <property name="view_methods">
+    <element value="view" />
+  </property>
+
+  <!-- Method aliases -->
+  <alias from="(Default)"
+         to="(dynamic view)"
+  />
+  <alias from="edit"
+         to="@@edit"
+  />
+  <alias from="sharing"
+         to="@@sharing"
+  />
+  <alias from="view"
+         to="(selected layout)"
+  />
+
+  <!-- Actions -->
+  <action action_id="view"
+          category="object"
+          condition_expr=""
+          title="View"
+          url_expr="string:${object_url}"
+          visible="True"
+          i18n:attributes="title"
+          i18n:domain="plone"
+  >
+    <permission value="View" />
+  </action>
+  <action action_id="edit"
+          category="object"
+          condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
+          title="Edit"
+          url_expr="string:${object_url}/edit"
+          visible="True"
+          i18n:attributes="title"
+          i18n:domain="plone"
+  >
+    <permission value="Modify portal content" />
+  </action>
+
+</object>

--- a/src/recensio/plone/profiles/default/types/Presentation_Monograph.xml
+++ b/src/recensio/plone/profiles/default/types/Presentation_Monograph.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Dexterity FTI"
+        name="Presentation Monograph"
+        i18n:domain="plone"
+>
+
+  <!-- Basic properties -->
+  <property name="title"
+            i18n:translate="title_presentation_monograph"
+  >Presentation Monograph</property>
+  <property name="description"
+            i18n:translate="description_presentation_monograph"
+  />
+
+  <property name="allow_discussion">False</property>
+  <property name="factory">Presentation Monograph</property>
+  <property name="icon_expr" />
+  <property name="link_target" />
+
+  <!-- Hierarchy control -->
+  <property name="global_allow">False</property>
+  <!-- Schema, class and security -->
+  <property name="add_permission">recensio.plone.AddPresentationMonograph</property>
+  <property name="klass">recensio.plone.content.presentation_monograph.PresentationMonograph</property>
+  <property name="model_file" />
+  <property name="model_source" />
+  <property name="schema">recensio.plone.content.presentation_monograph.IPresentationMonograph</property>
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors"
+            purge="false"
+  >
+    <element value="plone.basic" />
+    <element value="plone.namefromtitle" />
+    <element value="plone.allowdiscussion" />
+    <element value="plone.excludefromnavigation" />
+    <element value="plone.shortname" />
+    <element value="plone.ownership" />
+    <element value="plone.publication" />
+    <element value="plone.categorization" />
+    <element value="plone.locking" />
+  </property>
+
+  <!-- View information -->
+  <property name="add_view_expr">string:${folder_url}/++add++Presentation Monograph</property>
+  <property name="default_view">view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="immediate_view">view</property>
+  <property name="view_methods">
+    <element value="view" />
+  </property>
+
+  <!-- Method aliases -->
+  <alias from="(Default)"
+         to="(dynamic view)"
+  />
+  <alias from="edit"
+         to="@@edit"
+  />
+  <alias from="sharing"
+         to="@@sharing"
+  />
+  <alias from="view"
+         to="(selected layout)"
+  />
+
+  <!-- Actions -->
+  <action action_id="view"
+          category="object"
+          condition_expr=""
+          title="View"
+          url_expr="string:${object_url}"
+          visible="True"
+          i18n:attributes="title"
+          i18n:domain="plone"
+  >
+    <permission value="View" />
+  </action>
+  <action action_id="edit"
+          category="object"
+          condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
+          title="Edit"
+          url_expr="string:${object_url}/edit"
+          visible="True"
+          i18n:attributes="title"
+          i18n:domain="plone"
+  >
+    <permission value="Modify portal content" />
+  </action>
+
+</object>

--- a/src/recensio/plone/profiles/default/types/Presentation_Online_Resource.xml
+++ b/src/recensio/plone/profiles/default/types/Presentation_Online_Resource.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Dexterity FTI"
+        name="Presentation Online Resource"
+        i18n:domain="plone"
+>
+
+  <!-- Basic properties -->
+  <property name="title"
+            i18n:translate=""
+  >Presentation Online Resource</property>
+  <property name="description"
+            i18n:translate="description_presentation_online_resource"
+  />
+
+  <property name="allow_discussion">False</property>
+  <property name="factory">Presentation Online Resource</property>
+  <property name="icon_expr" />
+  <property name="link_target" />
+
+  <!-- Hierarchy control -->
+  <property name="global_allow">False</property>
+  <!-- Schema, class and security -->
+  <property name="add_permission">recensio.plone.AddPresentationOnlineResource</property>
+  <property name="klass">recensio.plone.content.presentation_online_resource.PresentationOnlineResource</property>
+  <property name="model_file" />
+  <property name="model_source" />
+  <property name="schema">recensio.plone.content.presentation_online_resource.IPresentationOnlineResource</property>
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors"
+            purge="false"
+  >
+    <element value="plone.basic" />
+    <element value="plone.namefromtitle" />
+    <element value="plone.allowdiscussion" />
+    <element value="plone.excludefromnavigation" />
+    <element value="plone.shortname" />
+    <element value="plone.ownership" />
+    <element value="plone.publication" />
+    <element value="plone.categorization" />
+    <element value="plone.locking" />
+  </property>
+
+  <!-- View information -->
+  <property name="add_view_expr">string:${folder_url}/++add++Presentation Online Resource</property>
+  <property name="default_view">view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="immediate_view">view</property>
+  <property name="view_methods">
+    <element value="view" />
+  </property>
+
+  <!-- Method aliases -->
+  <alias from="(Default)"
+         to="(dynamic view)"
+  />
+  <alias from="edit"
+         to="@@edit"
+  />
+  <alias from="sharing"
+         to="@@sharing"
+  />
+  <alias from="view"
+         to="(selected layout)"
+  />
+
+  <!-- Actions -->
+  <action action_id="view"
+          category="object"
+          condition_expr=""
+          title="View"
+          url_expr="string:${object_url}"
+          visible="True"
+          i18n:attributes="title"
+          i18n:domain="plone"
+  >
+    <permission value="View" />
+  </action>
+  <action action_id="edit"
+          category="object"
+          condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
+          title="Edit"
+          url_expr="string:${object_url}/edit"
+          visible="True"
+          i18n:attributes="title"
+          i18n:domain="plone"
+  >
+    <permission value="Modify portal content" />
+  </action>
+
+</object>

--- a/src/recensio/plone/profiles/default/types/Review_Exhibition.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Exhibition.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Dexterity FTI"
+        name="Review Exhibition"
+        i18n:domain="plone"
+>
+
+  <!-- Basic properties -->
+  <property name="title"
+            i18n:translate=""
+  >Review Exhibition</property>
+  <property name="description"
+            i18n:translate="description_review_exhibition"
+  />
+
+  <property name="allow_discussion">False</property>
+  <property name="factory">Review Exhibition</property>
+  <property name="icon_expr" />
+  <property name="link_target" />
+
+  <!-- Hierarchy control -->
+  <property name="global_allow">False</property>
+  <!-- Schema, class and security -->
+  <property name="add_permission">recensio.plone.AddReviewExhibition</property>
+  <property name="klass">recensio.plone.content.review_exhibition.ReviewExhibition</property>
+  <property name="model_file" />
+  <property name="model_source" />
+  <property name="schema">recensio.plone.content.review_exhibition.IReviewExhibition</property>
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors"
+            purge="false"
+  >
+    <element value="plone.basic" />
+    <element value="plone.namefromtitle" />
+    <element value="plone.allowdiscussion" />
+    <element value="plone.excludefromnavigation" />
+    <element value="plone.shortname" />
+    <element value="plone.ownership" />
+    <element value="plone.publication" />
+    <element value="plone.categorization" />
+    <element value="plone.locking" />
+  </property>
+
+  <!-- View information -->
+  <property name="add_view_expr">string:${folder_url}/++add++Review Exhibition</property>
+  <property name="default_view">view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="immediate_view">view</property>
+  <property name="view_methods">
+    <element value="view" />
+  </property>
+
+  <!-- Method aliases -->
+  <alias from="(Default)"
+         to="(dynamic view)"
+  />
+  <alias from="edit"
+         to="@@edit"
+  />
+  <alias from="sharing"
+         to="@@sharing"
+  />
+  <alias from="view"
+         to="(selected layout)"
+  />
+
+  <!-- Actions -->
+  <action action_id="view"
+          category="object"
+          condition_expr=""
+          title="View"
+          url_expr="string:${object_url}"
+          visible="True"
+          i18n:attributes="title"
+          i18n:domain="plone"
+  >
+    <permission value="View" />
+  </action>
+  <action action_id="edit"
+          category="object"
+          condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
+          title="Edit"
+          url_expr="string:${object_url}/edit"
+          visible="True"
+          i18n:attributes="title"
+          i18n:domain="plone"
+  >
+    <permission value="Modify portal content" />
+  </action>
+
+</object>


### PR DESCRIPTION
- More FTI content type stubs.
- Using the `recensio` instead `recensio.plone` i18:domain as it was the case with old recensio.

This is a WIP, you can merge and continue otherwise I will pick it up again later. But I have to run now.