### PR TITLE
Use recensio i18n domain.

### DIFF
--- a/src/recensio/plone/profiles/default/types/Issue.xml
+++ b/src/recensio/plone/profiles/default/types/Issue.xml
@@ -2,7 +2,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         meta_type="Dexterity FTI"
         name="Issue"
-        i18n:domain="recensio.plone"
+        i18n:domain="recensio"
 >
 
   <!-- Basic properties -->

--- a/src/recensio/plone/profiles/default/types/Issue.xml
+++ b/src/recensio/plone/profiles/default/types/Issue.xml
@@ -2,7 +2,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         meta_type="Dexterity FTI"
         name="Issue"
-        i18n:domain="recensio"
+        i18n:domain="plone"
 >
 
   <!-- Basic properties -->

--- a/src/recensio/plone/profiles/default/types/Person.xml
+++ b/src/recensio/plone/profiles/default/types/Person.xml
@@ -2,7 +2,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         meta_type="Dexterity FTI"
         name="Person"
-        i18n:domain="recensio.plone"
+        i18n:domain="recensio"
 >
 
   <!-- Basic properties -->

--- a/src/recensio/plone/profiles/default/types/Person.xml
+++ b/src/recensio/plone/profiles/default/types/Person.xml
@@ -2,7 +2,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         meta_type="Dexterity FTI"
         name="Person"
-        i18n:domain="recensio"
+        i18n:domain="plone"
 >
 
   <!-- Basic properties -->

--- a/src/recensio/plone/profiles/default/types/Publication.xml
+++ b/src/recensio/plone/profiles/default/types/Publication.xml
@@ -2,7 +2,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         meta_type="Dexterity FTI"
         name="Publication"
-        i18n:domain="recensio"
+        i18n:domain="plone"
 >
 
   <!-- Basic properties -->

--- a/src/recensio/plone/profiles/default/types/Publication.xml
+++ b/src/recensio/plone/profiles/default/types/Publication.xml
@@ -2,7 +2,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         meta_type="Dexterity FTI"
         name="Publication"
-        i18n:domain="recensio.plone"
+        i18n:domain="recensio"
 >
 
   <!-- Basic properties -->

--- a/src/recensio/plone/profiles/default/types/Review_Article_Collection.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Article_Collection.xml
@@ -2,7 +2,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         meta_type="Dexterity FTI"
         name="Review Article Collection"
-        i18n:domain="recensio"
+        i18n:domain="plone"
 >
 
   <!-- Basic properties -->

--- a/src/recensio/plone/profiles/default/types/Review_Article_Collection.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Article_Collection.xml
@@ -2,7 +2,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         meta_type="Dexterity FTI"
         name="Review Article Collection"
-        i18n:domain="recensio.plone"
+        i18n:domain="recensio"
 >
 
   <!-- Basic properties -->

--- a/src/recensio/plone/profiles/default/types/Review_Article_Journal.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Article_Journal.xml
@@ -2,7 +2,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         meta_type="Dexterity FTI"
         name="Review Article Journal"
-        i18n:domain="recensio"
+        i18n:domain="plone"
 >
 
   <!-- Basic properties -->

--- a/src/recensio/plone/profiles/default/types/Review_Article_Journal.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Article_Journal.xml
@@ -2,7 +2,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         meta_type="Dexterity FTI"
         name="Review Article Journal"
-        i18n:domain="recensio.plone"
+        i18n:domain="recensio"
 >
 
   <!-- Basic properties -->

--- a/src/recensio/plone/profiles/default/types/Review_Journal.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Journal.xml
@@ -2,7 +2,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         meta_type="Dexterity FTI"
         name="Review Journal"
-        i18n:domain="recensio.plone"
+        i18n:domain="recensio"
 >
 
   <!-- Basic properties -->

--- a/src/recensio/plone/profiles/default/types/Review_Journal.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Journal.xml
@@ -2,7 +2,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         meta_type="Dexterity FTI"
         name="Review Journal"
-        i18n:domain="recensio"
+        i18n:domain="plone"
 >
 
   <!-- Basic properties -->

--- a/src/recensio/plone/profiles/default/types/Review_Monograph.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Monograph.xml
@@ -2,7 +2,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         meta_type="Dexterity FTI"
         name="Review Monograph"
-        i18n:domain="recensio.plone"
+        i18n:domain="recensio"
 >
 
   <!-- Basic properties -->

--- a/src/recensio/plone/profiles/default/types/Review_Monograph.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Monograph.xml
@@ -2,7 +2,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         meta_type="Dexterity FTI"
         name="Review Monograph"
-        i18n:domain="recensio"
+        i18n:domain="plone"
 >
 
   <!-- Basic properties -->

--- a/src/recensio/plone/profiles/default/types/Volume.xml
+++ b/src/recensio/plone/profiles/default/types/Volume.xml
@@ -2,7 +2,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         meta_type="Dexterity FTI"
         name="Volume"
-        i18n:domain="recensio"
+        i18n:domain="plone"
 >
 
   <!-- Basic properties -->

--- a/src/recensio/plone/profiles/default/types/Volume.xml
+++ b/src/recensio/plone/profiles/default/types/Volume.xml
@@ -2,7 +2,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         meta_type="Dexterity FTI"
         name="Volume"
-        i18n:domain="recensio.plone"
+        i18n:domain="recensio"
 >
 
   <!-- Basic properties -->


### PR DESCRIPTION
~~We were mostly using the `recensio` domain. Not fully consistently, but mostly.
The `recensio.plone` package was also initially created with the `recensio` domain.
I suggest to use the `recensio` i18n:domain with this PR.~~

For the FTI types we were using the `plone` domain. The second commit fixes this.