### PR TITLE
Implement the Person content type.

### DIFF
--- a/src/recensio/plone/configure.zcml
+++ b/src/recensio/plone/configure.zcml
@@ -25,6 +25,7 @@
 
   <include package=".behaviors" />
   <include package=".browser" />
+  <include package=".content" />
   <include package=".upgrades" />
 
   <utility

--- a/src/recensio/plone/content/configure.zcml
+++ b/src/recensio/plone/content/configure.zcml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <adapter factory=".person.NameFromPerson" />
+
+</configure>

--- a/src/recensio/plone/content/person.py
+++ b/src/recensio/plone/content/person.py
@@ -1,12 +1,66 @@
+from plone.app.content.interfaces import INameFromTitle
+from plone.autoform import directives as form
+from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.supermodel import model
+from Products.CMFPlone import PloneMessageFactory as _PMF
+from recensio.plone import _
+from zope import schema
+from zope.component import adapter
 from zope.interface import implementer
+from zope.interface import provider
 
 
+@provider(IFormFieldProvider)
 class IPerson(model.Schema):
-    """Marker interface and Dexterity Python Schema for Person"""
+    """Marker interface and Dexterity Python Schema for Person."""
+
+    firstname = schema.TextLine(
+        title=_("First name"),
+        required=False,
+    )
+    lastname = schema.TextLine(
+        title=_("Last name"),
+        required=True,
+    )
+    gndId = schema.TextLine(
+        title=_("GND"),
+        description=_("help_gndId", default=""),
+        required=False,
+    )
+
+    # Define the necessary basic metadata fields `title` and `description` but
+    # do not show them in edit and add forms.
+    # Instead, the title is generated from the firstname and lastname.
+    title = schema.TextLine(
+        title=_PMF("label_title", default="Title"),
+        required=False,
+        missing_value="",
+    )
+    description = schema.Text(
+        title=_PMF("label_description", default="Summary"),
+        required=False,
+        missing_value="",
+    )
+    form.omitted("title", "description")
 
 
 @implementer(IPerson)
 class Person(Item):
-    """Content-type class for IPerson"""
+    """Content-type class for IPerson."""
+
+
+@implementer(INameFromTitle)
+@adapter(IPerson)
+class NameFromPerson:
+    def __new__(cls, context):
+        # Similar to:
+        # plone.app.dexterity.behaviors.filename.NameFromFileName
+        title = ", ".join([it for it in [context.lastname, context.firstname] if it])
+        instance = super().__new__(cls)
+        instance.title = title
+        context.title = title
+        return instance
+
+    def __init__(self, context):
+        pass

--- a/src/recensio/plone/profiles/default/types/Person.xml
+++ b/src/recensio/plone/profiles/default/types/Person.xml
@@ -21,7 +21,7 @@
   <!-- Hierarchy control -->
   <property name="global_allow">True</property>
   <!-- Schema, class and security -->
-  <property name="add_permission">recensio.plone.AddPerson</property>
+  <property name="add_permission">cmf.AddPortalContent</property>
   <property name="klass">recensio.plone.content.person.Person</property>
   <property name="model_file" />
   <property name="model_source" />
@@ -31,24 +31,11 @@
   <property name="behaviors"
             purge="false"
   >
-    <!-- Details about all standard behaviors following can be read at
-         https://docs.plone.org/external/plone.app.dexterity/docs/reference/standard-behaviours.html
-    -->
-    <element value="plone.basic" />
-    <element value="plone.namefromtitle" />
-    <element value="plone.allowdiscussion" />
-    <element value="plone.excludefromnavigation" />
-    <element value="plone.shortname" />
-    <element value="plone.ownership" />
-    <element value="plone.publication" />
     <element value="plone.categorization" />
     <element value="plone.locking" />
-    <!--<element value="plone.leadimage"/>-->
-    <!--<element value="plone.relateditems"/>-->
-    <!--<element value="plone.richtext"/>-->
-    <!--<element value="plone.tableofcontents"/>-->
-    <!--<element value="plone.versioning" />-->
-    <!--<element value="plone.translatable" />-->
+    <element value="plone.ownership" />
+    <element value="plone.publication" />
+    <element value="plone.shortname" />
   </property>
 
   <!-- View information -->


### PR DESCRIPTION
As with the `recensio.contenttype` person type, this person content type does not display title and description but sets the title from the given first- and lastname.

The schema follows the `recensio.contenttype` schema:
- same field names
- same msg ids
- same requires setting.