### PR TITLE
CT: Move fields to correct fieldsets

### DIFF
--- a/src/recensio/plone/behaviors/article.py
+++ b/src/recensio/plone/behaviors/article.py
@@ -2,7 +2,6 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -55,7 +54,7 @@ class IArticle(model.Schema):
         required=False,
     )
 
-    fieldset(
+    model.fieldset(
         "reviewed_text",
         label=_("label_schema_reviewed_text", default="Reviewed Text"),
         fields=[

--- a/src/recensio/plone/behaviors/article.py
+++ b/src/recensio/plone/behaviors/article.py
@@ -3,6 +3,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from zope import schema
 from zope.component import adapter
 from zope.interface import provider
@@ -54,10 +55,8 @@ class IArticle(model.Schema):
         required=False,
     )
 
-    model.fieldset(
-        "reviewed_text",
-        label=_("label_schema_reviewed_text", default="Reviewed Text"),
-        fields=[
+    fieldset_reviewed_text(
+        [
             "translatedTitle",
             "url_article",
             "urn_article",
@@ -65,7 +64,7 @@ class IArticle(model.Schema):
             "heading__page_number_of_article_in_journal_or_edited_volume",
             "pageStartOfArticle",
             "pageEndOfArticle",
-        ],
+        ]
     )
 
 

--- a/src/recensio/plone/behaviors/article.py
+++ b/src/recensio/plone/behaviors/article.py
@@ -2,6 +2,7 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -52,6 +53,20 @@ class IArticle(model.Schema):
     pageEndOfArticle = schema.Int(
         title=_("label_page_end_of_article_in_journal_or_edited_volume"),
         required=False,
+    )
+
+    fieldset(
+        "reviewed_text",
+        label=_("label_schema_reviewed_text", default="Reviewed Text"),
+        fields=[
+            "translatedTitle",
+            "url_article",
+            "urn_article",
+            "doi_article",
+            "heading__page_number_of_article_in_journal_or_edited_volume",
+            "pageStartOfArticle",
+            "pageEndOfArticle",
+        ],
     )
 
 

--- a/src/recensio/plone/behaviors/authors.py
+++ b/src/recensio/plone/behaviors/authors.py
@@ -4,7 +4,6 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
@@ -26,7 +25,7 @@ class IAuthors(model.Schema):
         required=False,
     )
 
-    fieldset(
+    model.fieldset(
         "reviewed_text",
         label=_("label_schema_reviewed_text", default="Reviewed Text"),
         fields=["authors"],

--- a/src/recensio/plone/behaviors/authors.py
+++ b/src/recensio/plone/behaviors/authors.py
@@ -4,6 +4,7 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
@@ -23,6 +24,12 @@ class IAuthors(model.Schema):
         defaultFactory=list,
         value_type=RelationChoice(source=CatalogSource(portal_type="Person")),
         required=False,
+    )
+
+    fieldset(
+        "reviewed_text",
+        label=_("label_schema_reviewed_text", default="Reviewed Text"),
+        fields=["authors"],
     )
 
 

--- a/src/recensio/plone/behaviors/authors.py
+++ b/src/recensio/plone/behaviors/authors.py
@@ -5,6 +5,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
 from zope.component import adapter
@@ -25,11 +26,7 @@ class IAuthors(model.Schema):
         required=False,
     )
 
-    model.fieldset(
-        "reviewed_text",
-        label=_("label_schema_reviewed_text", default="Reviewed Text"),
-        fields=["authors"],
-    )
+    fieldset_reviewed_text(["authors"])
 
 
 @adapter(IDexterityContent)

--- a/src/recensio/plone/behaviors/base.py
+++ b/src/recensio/plone/behaviors/base.py
@@ -11,6 +11,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.namedfile import field as namedfile
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from recensio.plone.utils import get_formatted_names
 from z3c.relationfield.schema import RelationChoice
@@ -22,12 +23,7 @@ from zope.i18nmessageid import Message
 from zope.interface import provider
 
 
-# from plone.supermodel.directives import fieldset
-
-
 # TODO, maybe:
-# - Move `title` to fieldset "reviewed_text"
-# - Move `subject` to fieldset "reviewed_text"
 # - Set content type for `generatedPdf` to `application/pdf`
 # - Set a character limit for `review`: 4000 characters
 # - Set rows for `review` to 20
@@ -124,7 +120,6 @@ class IBase(model.Schema):
     )
 
     # TODO
-    # schemata="reviewed_text",
     # size=10,
     ddcSubject = schema.Choice(
         title=_("ddc subject"),
@@ -133,7 +128,6 @@ class IBase(model.Schema):
     )
 
     # TODO
-    # schemata="reviewed_text",
     # size=10,
     ddcTime = schema.Choice(
         title=_("ddc time"),
@@ -142,7 +136,6 @@ class IBase(model.Schema):
     )
 
     # TODO
-    # schemata="reviewed_text",
     # size=10,
     ddcPlace = schema.Choice(
         title=_("ddc place"),
@@ -150,27 +143,30 @@ class IBase(model.Schema):
         required=False,
     )
 
-    # fieldset(
-    #    "reviewed_text",
-    #    label=_("label_schema_reviewed_text", default="Reviewed Text"),
-    #    fields=[
-    #        "languageReviewedText",
-    #    ],
-    # )
+    fieldset(
+        "reviewed_text",
+        label=_("label_schema_reviewed_text", default="Reviewed Text"),
+        fields=[
+            "languageReviewedText",
+            "ddcSubject",
+            "ddcTime",
+            "ddcPlace",
+        ],
+    )
 
-    # fieldset(
-    #    "review",
-    #    label=_("Review"),
-    #    fields=[
-    #        "reviewAuthors",
-    #        "languageReview",
-    #        "review",
-    #        "urn",
-    #        "bv",
-    #        "ppn",
-    #        "canonical_uri",
-    #    ],
-    # )
+    fieldset(
+        "review",
+        label=_("label_schema_review", default="Review"),
+        fields=[
+            "reviewAuthors",
+            "languageReview",
+            "review",
+            "urn",
+            "bv",
+            "ppn",
+            "canonical_uri",
+        ],
+    )
 
 
 @adapter(IDexterityContent)

--- a/src/recensio/plone/behaviors/base.py
+++ b/src/recensio/plone/behaviors/base.py
@@ -11,7 +11,6 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.namedfile import field as namedfile
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from recensio.plone.utils import get_formatted_names
 from z3c.relationfield.schema import RelationChoice
@@ -143,7 +142,7 @@ class IBase(model.Schema):
         required=False,
     )
 
-    fieldset(
+    model.fieldset(
         "reviewed_text",
         label=_("label_schema_reviewed_text", default="Reviewed Text"),
         fields=[
@@ -154,7 +153,7 @@ class IBase(model.Schema):
         ],
     )
 
-    fieldset(
+    model.fieldset(
         "review",
         label=_("label_schema_review", default="Review"),
         fields=[

--- a/src/recensio/plone/behaviors/base.py
+++ b/src/recensio/plone/behaviors/base.py
@@ -12,6 +12,8 @@ from plone.dexterity.interfaces import IDexterityContent
 from plone.namedfile import field as namedfile
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_review
+from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from recensio.plone.utils import get_formatted_names
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
@@ -142,10 +144,8 @@ class IBase(model.Schema):
         required=False,
     )
 
-    model.fieldset(
-        "reviewed_text",
-        label=_("label_schema_reviewed_text", default="Reviewed Text"),
-        fields=[
+    fieldset_reviewed_text(
+        [
             "languageReviewedText",
             "ddcSubject",
             "ddcTime",
@@ -153,10 +153,8 @@ class IBase(model.Schema):
         ],
     )
 
-    model.fieldset(
-        "review",
-        label=_("label_schema_review", default="Review"),
-        fields=[
+    fieldset_review(
+        [
             "reviewAuthors",
             "languageReview",
             "review",

--- a/src/recensio/plone/behaviors/base_presentation.py
+++ b/src/recensio/plone/behaviors/base_presentation.py
@@ -4,7 +4,6 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -75,7 +74,7 @@ class IBasePresentation(model.Schema):
         default=False,
     )
 
-    fieldset(
+    model.fieldset(
         "review",
         label=_("label_schema_presentation", default="Presentation"),
         fields=[

--- a/src/recensio/plone/behaviors/base_presentation.py
+++ b/src/recensio/plone/behaviors/base_presentation.py
@@ -4,6 +4,7 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -20,7 +21,6 @@ def get_user_home_page():
 
 @provider(IFormFieldProvider)
 class IBasePresentation(model.Schema):
-
     labelPresentationAuthor = schema.TextLine(
         title=_("label_presentation_author", default=("")),
         required=False,
@@ -73,6 +73,18 @@ class IBasePresentation(model.Schema):
         ),
         required=True,
         default=False,
+    )
+
+    fieldset(
+        "review",
+        label=_("label_schema_presentation", default="Presentation"),
+        fields=[
+            "labelPresentationAuthor",
+            "reviewAuthorHonorific",
+            "reviewAuthorEmail",
+            "reviewAuthorPersonalUrl",
+            "isLicenceApproved",
+        ],
     )
 
 

--- a/src/recensio/plone/behaviors/base_presentation.py
+++ b/src/recensio/plone/behaviors/base_presentation.py
@@ -5,6 +5,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_review
 from zope import schema
 from zope.component import adapter
 from zope.interface import provider
@@ -74,10 +75,8 @@ class IBasePresentation(model.Schema):
         default=False,
     )
 
-    model.fieldset(
-        "review",
-        label=_("label_schema_presentation", default="Presentation"),
-        fields=[
+    fieldset_review(
+        [
             "labelPresentationAuthor",
             "reviewAuthorHonorific",
             "reviewAuthorEmail",

--- a/src/recensio/plone/behaviors/base_review.py
+++ b/src/recensio/plone/behaviors/base_review.py
@@ -6,6 +6,7 @@ from plone.namedfile.field import NamedBlobFile
 from plone.namedfile.field import NamedBlobImage
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_review
 from z3c.form.interfaces import IAddForm
 from z3c.form.interfaces import IEditForm
 from zope import schema
@@ -86,10 +87,8 @@ class IBaseReview(model.Schema):
         required=False,
     )
 
-    model.fieldset(
-        "review",
-        label=_("label_schema_review", default="Review"),
-        fields=[
+    fieldset_review(
+        [
             "pdf",
             "doc",
             "customCitation",

--- a/src/recensio/plone/behaviors/base_review.py
+++ b/src/recensio/plone/behaviors/base_review.py
@@ -5,7 +5,6 @@ from plone.dexterity.interfaces import IDexterityContent
 from plone.namedfile.field import NamedBlobFile
 from plone.namedfile.field import NamedBlobImage
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from z3c.form.interfaces import IAddForm
 from z3c.form.interfaces import IEditForm
@@ -87,7 +86,7 @@ class IBaseReview(model.Schema):
         required=False,
     )
 
-    fieldset(
+    model.fieldset(
         "review",
         label=_("label_schema_review", default="Review"),
         fields=[

--- a/src/recensio/plone/behaviors/base_review.py
+++ b/src/recensio/plone/behaviors/base_review.py
@@ -5,6 +5,7 @@ from plone.dexterity.interfaces import IDexterityContent
 from plone.namedfile.field import NamedBlobFile
 from plone.namedfile.field import NamedBlobImage
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from z3c.form.interfaces import IAddForm
 from z3c.form.interfaces import IEditForm
@@ -84,6 +85,18 @@ class IBaseReview(model.Schema):
             "activated on the volume or issue.",
         ),
         required=False,
+    )
+
+    fieldset(
+        "review",
+        label=_("label_schema_review", default="Review"),
+        fields=[
+            "pdf",
+            "doc",
+            "customCitation",
+            "doi",
+            "customCoverImage",
+        ],
     )
 
 

--- a/src/recensio/plone/behaviors/book_review.py
+++ b/src/recensio/plone/behaviors/book_review.py
@@ -6,6 +6,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from zope import schema
 from zope.component import adapter
 from zope.interface import Interface
@@ -69,10 +70,8 @@ class IBookReview(model.Schema):
         required=False,
     )
 
-    model.fieldset(
-        "reviewed_text",
-        label=_("label_schema_reviewed_text", default="Reviewed Text"),
-        fields=[
+    fieldset_reviewed_text(
+        [
             "additionalTitles",
             "isbn",
             "isbn_online",

--- a/src/recensio/plone/behaviors/book_review.py
+++ b/src/recensio/plone/behaviors/book_review.py
@@ -5,6 +5,7 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -67,6 +68,19 @@ class IBookReview(model.Schema):
     doi_monograph = schema.TextLine(
         title=_("DOI (Monographie)"),
         required=False,
+    )
+
+    fieldset(
+        "reviewed_text",
+        label=_("label_schema_reviewed_text", default="Reviewed Text"),
+        fields=[
+            "additionalTitles",
+            "isbn",
+            "isbn_online",
+            "url_monograph",
+            "urn_monograph",
+            "doi_monograph",
+        ],
     )
 
 

--- a/src/recensio/plone/behaviors/book_review.py
+++ b/src/recensio/plone/behaviors/book_review.py
@@ -5,7 +5,6 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -70,7 +69,7 @@ class IBookReview(model.Schema):
         required=False,
     )
 
-    fieldset(
+    model.fieldset(
         "reviewed_text",
         label=_("label_schema_reviewed_text", default="Reviewed Text"),
         fields=[

--- a/src/recensio/plone/behaviors/cover_picture.py
+++ b/src/recensio/plone/behaviors/cover_picture.py
@@ -2,7 +2,6 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.namedfile.field import NamedBlobImage
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope.component import adapter
 from zope.interface import provider
@@ -15,7 +14,7 @@ class ICoverPicture(model.Schema):
         required=False,
     )
 
-    fieldset(
+    model.fieldset(
         "reviewed_text",
         label=_("label_schema_reviewed_text", default="Reviewed Text"),
         fields=["coverPicture"],

--- a/src/recensio/plone/behaviors/cover_picture.py
+++ b/src/recensio/plone/behaviors/cover_picture.py
@@ -3,6 +3,7 @@ from plone.dexterity.interfaces import IDexterityContent
 from plone.namedfile.field import NamedBlobImage
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from zope.component import adapter
 from zope.interface import provider
 
@@ -14,11 +15,7 @@ class ICoverPicture(model.Schema):
         required=False,
     )
 
-    model.fieldset(
-        "reviewed_text",
-        label=_("label_schema_reviewed_text", default="Reviewed Text"),
-        fields=["coverPicture"],
-    )
+    fieldset_reviewed_text(["coverPicture"])
 
 
 @adapter(IDexterityContent)

--- a/src/recensio/plone/behaviors/cover_picture.py
+++ b/src/recensio/plone/behaviors/cover_picture.py
@@ -2,6 +2,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.namedfile.field import NamedBlobImage
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope.component import adapter
 from zope.interface import provider
@@ -12,6 +13,12 @@ class ICoverPicture(model.Schema):
     coverPicture = NamedBlobImage(
         title=_("Cover picture"),
         required=False,
+    )
+
+    fieldset(
+        "reviewed_text",
+        label=_("label_schema_reviewed_text", default="Reviewed Text"),
+        fields=["coverPicture"],
     )
 
 

--- a/src/recensio/plone/behaviors/directives.py
+++ b/src/recensio/plone/behaviors/directives.py
@@ -1,0 +1,36 @@
+from plone.supermodel import model
+from plone.supermodel.interfaces import DEFAULT_ORDER
+from recensio.plone import _
+
+
+class fieldset(model.fieldset):
+    id = None
+    label = None
+    description = None
+    order = DEFAULT_ORDER
+
+    def factory(self, fields=[], **kw):
+        """Add fields to the fieldset."""
+        return super().factory(
+            self.id,
+            label=self.label,
+            description=self.description,
+            fields=fields,
+            order=self.order,
+            **kw
+        )
+
+
+class fieldset_reviewed_text(fieldset):
+    id = "reviewed_text"
+    label = _("label_schema_reviewed_text", default="Reviewed Text")
+
+
+class fieldset_review(fieldset):
+    id = "review"
+    label = _("label_schema_review", default="Review")
+
+
+class fieldset_exhibition(fieldset):
+    id = ("exhibition",)
+    label = (_("label_schema_exhibition", default="Ausstellung"),)

--- a/src/recensio/plone/behaviors/editorial.py
+++ b/src/recensio/plone/behaviors/editorial.py
@@ -4,7 +4,6 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
@@ -42,7 +41,7 @@ class IEditorial(model.Schema):
         pattern_options={"mode": "auto", "favorites": []},
     )
 
-    fieldset(
+    model.fieldset(
         "reviewed_text",
         label=_("label_schema_reviewed_text", default="Reviewed Text"),
         fields=[

--- a/src/recensio/plone/behaviors/editorial.py
+++ b/src/recensio/plone/behaviors/editorial.py
@@ -5,6 +5,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
 from zope import schema
@@ -41,14 +42,7 @@ class IEditorial(model.Schema):
         pattern_options={"mode": "auto", "favorites": []},
     )
 
-    model.fieldset(
-        "reviewed_text",
-        label=_("label_schema_reviewed_text", default="Reviewed Text"),
-        fields=[
-            "help_authors_or_editors",
-            "editorial",
-        ],
-    )
+    fieldset_reviewed_text(["help_authors_or_editors", "editorial"])
 
 
 @adapter(IDexterityContent)

--- a/src/recensio/plone/behaviors/editorial.py
+++ b/src/recensio/plone/behaviors/editorial.py
@@ -4,6 +4,7 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
@@ -39,6 +40,15 @@ class IEditorial(model.Schema):
         "editorial",
         RelatedItemsFieldWidget,
         pattern_options={"mode": "auto", "favorites": []},
+    )
+
+    fieldset(
+        "reviewed_text",
+        label=_("label_schema_reviewed_text", default="Reviewed Text"),
+        fields=[
+            "help_authors_or_editors",
+            "editorial",
+        ],
     )
 
 

--- a/src/recensio/plone/behaviors/journal_review.py
+++ b/src/recensio/plone/behaviors/journal_review.py
@@ -1,7 +1,6 @@
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -63,7 +62,7 @@ class IJournalReview(model.Schema):
         required=False,
     )
 
-    fieldset(
+    model.fieldset(
         "reviewed_text",
         label=_("label_schema_reviewed_text", default="Reviewed Text"),
         fields=[

--- a/src/recensio/plone/behaviors/journal_review.py
+++ b/src/recensio/plone/behaviors/journal_review.py
@@ -2,6 +2,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from zope import schema
 from zope.component import adapter
 from zope.interface import provider
@@ -62,10 +63,8 @@ class IJournalReview(model.Schema):
         required=False,
     )
 
-    model.fieldset(
-        "reviewed_text",
-        label=_("label_schema_reviewed_text", default="Reviewed Text"),
-        fields=[
+    fieldset_reviewed_text(
+        [
             "issn",
             "issn_online",
             "url_journal",

--- a/src/recensio/plone/behaviors/journal_review.py
+++ b/src/recensio/plone/behaviors/journal_review.py
@@ -1,6 +1,7 @@
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -60,6 +61,22 @@ class IJournalReview(model.Schema):
     officialYearOfPublication = schema.TextLine(
         title=_("Official year of publication (if different)"),
         required=False,
+    )
+
+    fieldset(
+        "reviewed_text",
+        label=_("label_schema_reviewed_text", default="Reviewed Text"),
+        fields=[
+            "issn",
+            "issn_online",
+            "url_journal",
+            "urn_journal",
+            "doi_journal",
+            "shortnameJournal",
+            "volumeNumber",
+            "issueNumber",
+            "officialYearOfPublication",
+        ],
     )
 
 

--- a/src/recensio/plone/behaviors/pages_of_presented_text.py
+++ b/src/recensio/plone/behaviors/pages_of_presented_text.py
@@ -2,7 +2,6 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -31,7 +30,7 @@ class IPagesOfPresentedText(model.Schema):
     # but I have to think more about it
     directives.mode(heading__page_number_of_presented_text_in_print="display")
 
-    fieldset(
+    model.fieldset(
         "reviewed_text",
         label=_("label_schema_reviewed_text", default="Reviewed Text"),
         fields=[
@@ -39,7 +38,7 @@ class IPagesOfPresentedText(model.Schema):
         ],
     )
 
-    fieldset(
+    model.fieldset(
         "presented_text",
         label=_("label_schema_presented_text", default="Presented Text"),
         fields=[

--- a/src/recensio/plone/behaviors/pages_of_presented_text.py
+++ b/src/recensio/plone/behaviors/pages_of_presented_text.py
@@ -3,6 +3,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from zope import schema
 from zope.component import adapter
 from zope.interface import provider
@@ -30,10 +31,8 @@ class IPagesOfPresentedText(model.Schema):
     # but I have to think more about it
     directives.mode(heading__page_number_of_presented_text_in_print="display")
 
-    model.fieldset(
-        "reviewed_text",
-        label=_("label_schema_reviewed_text", default="Reviewed Text"),
-        fields=[
+    fieldset_reviewed_text(
+        [
             "heading__page_number_of_presented_text_in_print",
             "pageStartOfPresentedTextInPrint",
             "pageEndOfPresentedTextInPrint",

--- a/src/recensio/plone/behaviors/pages_of_presented_text.py
+++ b/src/recensio/plone/behaviors/pages_of_presented_text.py
@@ -35,13 +35,6 @@ class IPagesOfPresentedText(model.Schema):
         label=_("label_schema_reviewed_text", default="Reviewed Text"),
         fields=[
             "heading__page_number_of_presented_text_in_print",
-        ],
-    )
-
-    model.fieldset(
-        "presented_text",
-        label=_("label_schema_presented_text", default="Presented Text"),
-        fields=[
             "pageStartOfPresentedTextInPrint",
             "pageEndOfPresentedTextInPrint",
         ],

--- a/src/recensio/plone/behaviors/pages_of_presented_text.py
+++ b/src/recensio/plone/behaviors/pages_of_presented_text.py
@@ -2,6 +2,7 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -29,6 +30,23 @@ class IPagesOfPresentedText(model.Schema):
     # XXX It is probably better to use a custom widget with a schema.Field,
     # but I have to think more about it
     directives.mode(heading__page_number_of_presented_text_in_print="display")
+
+    fieldset(
+        "reviewed_text",
+        label=_("label_schema_reviewed_text", default="Reviewed Text"),
+        fields=[
+            "heading__page_number_of_presented_text_in_print",
+        ],
+    )
+
+    fieldset(
+        "presented_text",
+        label=_("label_schema_presented_text", default="Presented Text"),
+        fields=[
+            "pageStartOfPresentedTextInPrint",
+            "pageEndOfPresentedTextInPrint",
+        ],
+    )
 
 
 @adapter(IDexterityContent)

--- a/src/recensio/plone/behaviors/printed_review.py
+++ b/src/recensio/plone/behaviors/printed_review.py
@@ -4,6 +4,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from zope import schema
 from zope.component import adapter
 from zope.interface import provider
@@ -60,10 +61,8 @@ class IPrintedReview(model.Schema):
     )
     directives.omitted("idBvb")
 
-    model.fieldset(
-        "reviewed_text",
-        label=_("label_schema_reviewed_text", default="Reviewed Text"),
-        fields=[
+    fieldset_reviewed_text(
+        [
             "heading_presented_work",
             "subtitle",
             "yearOfPublication",

--- a/src/recensio/plone/behaviors/printed_review.py
+++ b/src/recensio/plone/behaviors/printed_review.py
@@ -3,6 +3,7 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -59,6 +60,22 @@ class IPrintedReview(model.Schema):
         required=False,
     )
     directives.omitted("idBvb")
+
+    fieldset(
+        "reviewed_text",
+        label=_("label_schema_reviewed_text", default="Reviewed Text"),
+        fields=[
+            "heading_presented_work",
+            "subtitle",
+            "yearOfPublication",
+            "placeOfPublication",
+            "publisher",
+            "yearOfPublicationOnline",
+            "placeOfPublicationOnline",
+            "publisherOnline",
+            "idBvb",
+        ],
+    )
 
 
 @adapter(IDexterityContent)

--- a/src/recensio/plone/behaviors/printed_review.py
+++ b/src/recensio/plone/behaviors/printed_review.py
@@ -3,7 +3,6 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -61,7 +60,7 @@ class IPrintedReview(model.Schema):
     )
     directives.omitted("idBvb")
 
-    fieldset(
+    model.fieldset(
         "reviewed_text",
         label=_("label_schema_reviewed_text", default="Reviewed Text"),
         fields=[

--- a/src/recensio/plone/behaviors/reference_authors.py
+++ b/src/recensio/plone/behaviors/reference_authors.py
@@ -4,6 +4,7 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -40,6 +41,14 @@ class IReferenceAuthors(model.Schema):
         description=_("Enter data here. New rows will be added automatically."),
         value_type=DictRow(schema=IReferenceAuthorRowSchema, required=False),
         required=False,
+    )
+
+    fieldset(
+        "review",
+        label=_("label_schema_review", default="Review"),
+        fields=[
+            "referenceAuthors",
+        ],
     )
 
 

--- a/src/recensio/plone/behaviors/reference_authors.py
+++ b/src/recensio/plone/behaviors/reference_authors.py
@@ -5,6 +5,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_review
 from zope import schema
 from zope.component import adapter
 from zope.interface import Interface
@@ -42,13 +43,7 @@ class IReferenceAuthors(model.Schema):
         required=False,
     )
 
-    model.fieldset(
-        "review",
-        label=_("label_schema_review", default="Review"),
-        fields=[
-            "referenceAuthors",
-        ],
-    )
+    fieldset_review(["referenceAuthors"])
 
 
 @adapter(IDexterityContent)

--- a/src/recensio/plone/behaviors/reference_authors.py
+++ b/src/recensio/plone/behaviors/reference_authors.py
@@ -4,7 +4,6 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -43,7 +42,7 @@ class IReferenceAuthors(model.Schema):
         required=False,
     )
 
-    fieldset(
+    model.fieldset(
         "review",
         label=_("label_schema_review", default="Review"),
         fields=[

--- a/src/recensio/plone/behaviors/serial.py
+++ b/src/recensio/plone/behaviors/serial.py
@@ -2,6 +2,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from zope import schema
 from zope.component import adapter
 from zope.interface import provider
@@ -24,15 +25,7 @@ class ISerial(model.Schema):
         required=False,
     )
 
-    model.fieldset(
-        "reviewed_text",
-        label=_("label_schema_reviewed_text", default="Reviewed Text"),
-        fields=[
-            "series",
-            "seriesVol",
-            "pages",
-        ],
-    )
+    fieldset_reviewed_text(["series", "seriesVol", "pages"])
 
 
 @adapter(IDexterityContent)

--- a/src/recensio/plone/behaviors/serial.py
+++ b/src/recensio/plone/behaviors/serial.py
@@ -1,6 +1,7 @@
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -22,6 +23,16 @@ class ISerial(model.Schema):
     pages = schema.TextLine(
         title=_("Pages"),
         required=False,
+    )
+
+    fieldset(
+        "reviewed_text",
+        label=_("label_schema_reviewed_text", default="Reviewed Text"),
+        fields=[
+            "series",
+            "seriesVol",
+            "pages",
+        ],
     )
 
 

--- a/src/recensio/plone/behaviors/serial.py
+++ b/src/recensio/plone/behaviors/serial.py
@@ -1,7 +1,6 @@
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -25,7 +24,7 @@ class ISerial(model.Schema):
         required=False,
     )
 
-    fieldset(
+    model.fieldset(
         "reviewed_text",
         label=_("label_schema_reviewed_text", default="Reviewed Text"),
         fields=[

--- a/src/recensio/plone/behaviors/settings_url_in_citation.py
+++ b/src/recensio/plone/behaviors/settings_url_in_citation.py
@@ -1,7 +1,6 @@
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -39,7 +38,7 @@ class ISettingsURLInCitation(model.Schema):
         required=False,
     )
 
-    fieldset(
+    model.fieldset(
         "review",
         label=_("label_schema_review", default="Review"),
         fields=[

--- a/src/recensio/plone/behaviors/settings_url_in_citation.py
+++ b/src/recensio/plone/behaviors/settings_url_in_citation.py
@@ -1,6 +1,7 @@
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from zope import schema
 from zope.component import adapter
@@ -25,7 +26,6 @@ description_is_url_shown_in_citation_note = _(
 @provider(IFormFieldProvider)
 class ISettingsURLInCitation(model.Schema):
     # TODO:
-    # schemata="review",
     # condition="python:object.aq_parent.isURLShownInCitationNote() if object.aq_parent != object else True",
     # Show only as label, if:
     #     condition="python:not object.aq_parent.isURLShownInCitationNote() if object.aq_parent != object else False",
@@ -37,6 +37,14 @@ class ISettingsURLInCitation(model.Schema):
         description=description_is_url_shown_in_citation_note,
         default=True,
         required=False,
+    )
+
+    fieldset(
+        "review",
+        label=_("label_schema_review", default="Review"),
+        fields=[
+            "URLShownInCitationNote",
+        ],
     )
 
 

--- a/src/recensio/plone/behaviors/settings_url_in_citation.py
+++ b/src/recensio/plone/behaviors/settings_url_in_citation.py
@@ -2,6 +2,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_review
 from zope import schema
 from zope.component import adapter
 from zope.interface import provider
@@ -38,13 +39,7 @@ class ISettingsURLInCitation(model.Schema):
         required=False,
     )
 
-    model.fieldset(
-        "review",
-        label=_("label_schema_review", default="Review"),
-        fields=[
-            "URLShownInCitationNote",
-        ],
-    )
+    fieldset_review(["URLShownInCitationNote"])
 
 
 @adapter(IDexterityContent)

--- a/src/recensio/plone/content/review_article_journal.py
+++ b/src/recensio/plone/content/review_article_journal.py
@@ -1,7 +1,6 @@
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
 from recensio.plone.utils import getFormatter
@@ -36,7 +35,7 @@ class IReviewArticleJournal(model.Schema):
         required=False,
     )
 
-    fieldset(
+    model.fieldset(
         "reviewed_text",
         label=_("label_schema_reviewed_text", default="Reviewed Text"),
         fields=[

--- a/src/recensio/plone/content/review_article_journal.py
+++ b/src/recensio/plone/content/review_article_journal.py
@@ -3,6 +3,7 @@ from plone.dexterity.content import Item
 from plone.supermodel import model
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
+from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from recensio.plone.utils import getFormatter
 from recensio.plone.utils import punctuated_title_and_subtitle
 from zope import schema
@@ -35,14 +36,7 @@ class IReviewArticleJournal(model.Schema):
         required=False,
     )
 
-    model.fieldset(
-        "reviewed_text",
-        label=_("label_schema_reviewed_text", default="Reviewed Text"),
-        fields=[
-            "editor",
-            "translatedTitleJournal",
-        ],
-    )
+    fieldset_reviewed_text(["editor", "translatedTitleJournal"])
 
 
 # TODO

--- a/src/recensio/plone/content/review_article_journal.py
+++ b/src/recensio/plone/content/review_article_journal.py
@@ -1,6 +1,7 @@
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
 from recensio.plone.utils import getFormatter
@@ -17,8 +18,6 @@ class IReviewArticleJournal(model.Schema):
     """Marker interface and Dexterity Python Schema for
     ReviewArticleJournal."""
 
-    # TODO
-    # schemata="reviewed_text",
     editor = schema.TextLine(
         title=_("Editor (name or institution)"),
         required=False,
@@ -29,14 +28,21 @@ class IReviewArticleJournal(model.Schema):
         required=True,
     )
 
-    # TODO
-    # schemata="reviewed_text",
     translatedTitleJournal = schema.TextLine(
         title=_(
             "label_translated_title_journal",
             default="Translated title (Journal)",
         ),
         required=False,
+    )
+
+    fieldset(
+        "reviewed_text",
+        label=_("label_schema_reviewed_text", default="Reviewed Text"),
+        fields=[
+            "editor",
+            "translatedTitleJournal",
+        ],
     )
 
 

--- a/src/recensio/plone/content/review_exhibition.py
+++ b/src/recensio/plone/content/review_exhibition.py
@@ -5,7 +5,6 @@ from plone.app.z3cform.widget import RelatedItemsFieldWidget
 from plone.autoform.directives import widget
 from plone.dexterity.content import Item
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
 from recensio.plone.utils import get_formatted_names
@@ -135,7 +134,7 @@ class IReviewExhibition(model.Schema):
         required=False,
     )
 
-    fieldset(
+    model.fieldset(
         "exhibition",
         label=_("label_schema_exhibition", default="Ausstellung"),
         fields=[

--- a/src/recensio/plone/content/review_exhibition.py
+++ b/src/recensio/plone/content/review_exhibition.py
@@ -5,6 +5,7 @@ from plone.app.z3cform.widget import RelatedItemsFieldWidget
 from plone.autoform.directives import widget
 from plone.dexterity.content import Item
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
 from recensio.plone.utils import get_formatted_names
@@ -132,6 +133,22 @@ class IReviewExhibition(model.Schema):
     doi_exhibition = schema.TextLine(
         title=_("DOI der Ausstellungswebsite"),
         required=False,
+    )
+
+    fieldset(
+        "exhibition",
+        label=_("label_schema_exhibition", default="Ausstellung"),
+        fields=[
+            "exhibiting_institution",
+            "dates",
+            "years",
+            "exhibiting_organisation",
+            "curators",
+            "isPermanentExhibition",
+            "titleProxy",
+            "url_exhibition",
+            "doi_exhibition",
+        ],
     )
 
 

--- a/src/recensio/plone/content/review_exhibition.py
+++ b/src/recensio/plone/content/review_exhibition.py
@@ -7,6 +7,7 @@ from plone.dexterity.content import Item
 from plone.supermodel import model
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
+from recensio.plone.behaviors.directives import fieldset_exhibition
 from recensio.plone.utils import get_formatted_names
 from recensio.plone.utils import getFormatter
 from recensio.plone.utils import punctuated_title_and_subtitle
@@ -134,10 +135,8 @@ class IReviewExhibition(model.Schema):
         required=False,
     )
 
-    model.fieldset(
-        "exhibition",
-        label=_("label_schema_exhibition", default="Ausstellung"),
-        fields=[
+    fieldset_exhibition(
+        [
             "exhibiting_institution",
             "dates",
             "years",

--- a/src/recensio/plone/content/review_journal.py
+++ b/src/recensio/plone/content/review_journal.py
@@ -3,6 +3,7 @@ from plone.dexterity.content import Item
 from plone.supermodel import model
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
+from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from recensio.plone.utils import getFormatter
 from zope import schema
 from zope.interface import implementer
@@ -24,14 +25,7 @@ class IReviewJournal(model.Schema):
         ),
     )
 
-    model.fieldset(
-        "reviewed_text",
-        label=_("label_schema_reviewed_text", default="Reviewed Text"),
-        fields=[
-            "editor",
-            "translatedTitleJournal",
-        ],
-    )
+    fieldset_reviewed_text(["editor", "translatedTitleJournal"])
 
 
 # TODO

--- a/src/recensio/plone/content/review_journal.py
+++ b/src/recensio/plone/content/review_journal.py
@@ -1,7 +1,6 @@
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
 from recensio.plone.utils import getFormatter
@@ -25,7 +24,7 @@ class IReviewJournal(model.Schema):
         ),
     )
 
-    fieldset(
+    model.fieldset(
         "reviewed_text",
         label=_("label_schema_reviewed_text", default="Reviewed Text"),
         fields=[

--- a/src/recensio/plone/content/review_journal.py
+++ b/src/recensio/plone/content/review_journal.py
@@ -1,6 +1,7 @@
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
 from recensio.plone.utils import getFormatter
@@ -13,19 +14,24 @@ from zope.interface import provider
 class IReviewJournal(model.Schema):
     """Marker interface and Dexterity Python Schema for ReviewJournal."""
 
-    # TODO
-    # schemata="reviewed_text",
     editor = schema.TextLine(
         title=_("Editor (name or institution)"),
     )
 
-    # TODO
-    # schemata="reviewed_text",
     translatedTitleJournal = schema.TextLine(
         title=_(
             "label_translated_title_journal",
             default="Translated title (Journal)",
         ),
+    )
+
+    fieldset(
+        "reviewed_text",
+        label=_("label_schema_reviewed_text", default="Reviewed Text"),
+        fields=[
+            "editor",
+            "translatedTitleJournal",
+        ],
     )
 
 

--- a/src/recensio/plone/content/review_monograph.py
+++ b/src/recensio/plone/content/review_monograph.py
@@ -1,7 +1,6 @@
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.supermodel import model
-from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
 from recensio.plone.utils import getFormatter
@@ -20,7 +19,7 @@ class IReviewMonograph(model.Schema):
         required=False,
     )
 
-    fieldset(
+    model.fieldset(
         "reviewed_text",
         label=_("label_schema_reviewed_text", default="Reviewed Text"),
         fields=[

--- a/src/recensio/plone/content/review_monograph.py
+++ b/src/recensio/plone/content/review_monograph.py
@@ -3,6 +3,7 @@ from plone.dexterity.content import Item
 from plone.supermodel import model
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
+from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from recensio.plone.utils import getFormatter
 from recensio.plone.utils import punctuated_title_and_subtitle
 from zope import schema
@@ -19,13 +20,7 @@ class IReviewMonograph(model.Schema):
         required=False,
     )
 
-    model.fieldset(
-        "reviewed_text",
-        label=_("label_schema_reviewed_text", default="Reviewed Text"),
-        fields=[
-            "translatedTitle",
-        ],
-    )
+    fieldset_reviewed_text(["translatedTitle"])
 
 
 @implementer(IReviewMonograph)

--- a/src/recensio/plone/content/review_monograph.py
+++ b/src/recensio/plone/content/review_monograph.py
@@ -1,6 +1,7 @@
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.supermodel import model
+from plone.supermodel.directives import fieldset
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
 from recensio.plone.utils import getFormatter
@@ -14,11 +15,17 @@ from zope.interface import provider
 class IReviewMonograph(model.Schema):
     """Marker interface and Dexterity Python Schema for ReviewMonograph."""
 
-    # TODO
-    # schemata="reviewed_text"
     translatedTitle = schema.TextLine(
         title=_("Translated Title"),
         required=False,
+    )
+
+    fieldset(
+        "reviewed_text",
+        label=_("label_schema_reviewed_text", default="Reviewed Text"),
+        fields=[
+            "translatedTitle",
+        ],
     )
 
 


### PR DESCRIPTION
Ref: https://github.com/syslabcom/scrum/issues/900

There are 4 commits - the original one, 2 review resolves and the last one going for a new approach where the label translations are not always repeated but defined just once. Not sure, if you like this.