### PR TITLE
Disallow discussion on most types

### DIFF
--- a/src/recensio/plone/profiles/default/types/Issue.xml
+++ b/src/recensio/plone/profiles/default/types/Issue.xml
@@ -41,7 +41,6 @@
   <property name="behaviors"
             purge="false"
   >
-    <element value="plone.allowdiscussion" />
     <element value="plone.basic" />
     <element value="plone.categorization" />
     <element value="plone.excludefromnavigation" />

--- a/src/recensio/plone/profiles/default/types/Publication.xml
+++ b/src/recensio/plone/profiles/default/types/Publication.xml
@@ -38,7 +38,6 @@
   <property name="behaviors"
             purge="false"
   >
-    <element value="plone.allowdiscussion" />
     <element value="plone.basic" />
     <element value="plone.categorization" />
     <element value="plone.excludefromnavigation" />

--- a/src/recensio/plone/profiles/default/types/Review_Article_Collection.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Article_Collection.xml
@@ -31,7 +31,6 @@
   <property name="behaviors"
             purge="false"
   >
-    <element value="plone.allowdiscussion" />
     <element value="plone.basic" />
     <element value="plone.categorization" />
     <element value="plone.excludefromnavigation" />

--- a/src/recensio/plone/profiles/default/types/Review_Article_Journal.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Article_Journal.xml
@@ -38,7 +38,6 @@
   <property name="behaviors"
             purge="false"
   >
-    <element value="plone.allowdiscussion" />
     <element value="plone.basic" />
     <element value="plone.categorization" />
     <element value="plone.excludefromnavigation" />

--- a/src/recensio/plone/profiles/default/types/Review_Exhibition.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Exhibition.xml
@@ -31,7 +31,6 @@
   <property name="behaviors"
             purge="false"
   >
-    <element value="plone.allowdiscussion" />
     <element value="plone.basic" />
     <element value="plone.categorization" />
     <element value="plone.excludefromnavigation" />

--- a/src/recensio/plone/profiles/default/types/Review_Journal.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Journal.xml
@@ -38,7 +38,6 @@
   <property name="behaviors"
             purge="false"
   >
-    <element value="plone.allowdiscussion" />
     <element value="plone.basic" />
     <element value="plone.categorization" />
     <element value="plone.excludefromnavigation" />

--- a/src/recensio/plone/profiles/default/types/Review_Monograph.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Monograph.xml
@@ -38,7 +38,6 @@
   <property name="behaviors"
             purge="false"
   >
-    <element value="plone.allowdiscussion" />
     <element value="plone.basic" />
     <element value="plone.categorization" />
     <element value="plone.excludefromnavigation" />

--- a/src/recensio/plone/profiles/default/types/Volume.xml
+++ b/src/recensio/plone/profiles/default/types/Volume.xml
@@ -42,7 +42,6 @@
   <property name="behaviors"
             purge="false"
   >
-    <element value="plone.allowdiscussion" />
     <element value="plone.basic" />
     <element value="plone.categorization" />
     <element value="plone.excludefromnavigation" />


### PR DESCRIPTION
Only presentations should have discussion support.

(Note that new comments should not be addable at all, but existing comments on presentations should be displayed.)

syslabcom/scrum#884