### PR TITLE
CT base: Add missing attributes + integrate vdex vocabs.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -40,3 +40,7 @@ tarjan = 0.2.3.2
 
 # collective.z3cform.datagridfield pins
 collective.z3cform.datagridfield = 3.0.0
+
+# collective.vdexvocabulary pins
+collective.vdexvocabulary = 0.3
+imsvdex = 1.2

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -26,21 +26,15 @@ eggs = createcoverage
 
 
 [versions]
+argcomplete = 2.0.0
+collective.vdexvocabulary = 0.3
+collective.z3cform.datagridfield = 3.0.0
 coverage = 7.0.5
 createcoverage = 1.5
-
-# ftw.upgrade pins
-argcomplete = 2.0.0
 ftw.upgrade = 3.3.1
+imsvdex = 1.2
 inflection = 0.5.1
 path = 16.6.0
 path.py = 12.5.0
 psutil = 5.9.4
 tarjan = 0.2.3.2
-
-# collective.z3cform.datagridfield pins
-collective.z3cform.datagridfield = 3.0.0
-
-# collective.vdexvocabulary pins
-collective.vdexvocabulary = 0.3
-imsvdex = 1.2

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -37,3 +37,6 @@ path = 16.6.0
 path.py = 12.5.0
 psutil = 5.9.4
 tarjan = 0.2.3.2
+
+# collective.z3cform.datagridfield pins
+collective.z3cform.datagridfield = 3.0.0

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "setuptools",
         "ftw.upgrade",
         "plone.api",
+        "collective.vdexvocabulary",
         "collective.z3cform.datagridfield",
     ],
     extras_require={

--- a/src/recensio/plone/behaviors/base.py
+++ b/src/recensio/plone/behaviors/base.py
@@ -119,6 +119,33 @@ class IBase(model.Schema):
         required=False,
     )
 
+    # TODO
+    # schemata="reviewed_text",
+    # size=10,
+    ddcSubject = schema.Choice(
+        title=_("ddc subject"),
+        vocabulary="recensio.plone.vocabularies.topic_values",
+        required=False,
+    )
+
+    # TODO
+    # schemata="reviewed_text",
+    # size=10,
+    ddcTime = schema.Choice(
+        title=_("ddc time"),
+        vocabulary="recensio.plone.vocabularies.epoch_values",
+        required=False,
+    )
+
+    # TODO
+    # schemata="reviewed_text",
+    # size=10,
+    ddcPlace = schema.Choice(
+        title=_("ddc place"),
+        vocabulary="recensio.plone.vocabularies.region_values",
+        required=False,
+    )
+
     # fieldset(
     #    "reviewed_text",
     #    label=_("label_schema_reviewed_text", default="Reviewed Text"),

--- a/src/recensio/plone/configure.zcml
+++ b/src/recensio/plone/configure.zcml
@@ -7,7 +7,10 @@
 
   <i18n:registerTranslations directory="locales" />
 
-  <include package="collective.vdexvocabulary" file="meta.zcml" />
+  <include
+      package="collective.vdexvocabulary"
+      file="meta.zcml"
+      />
   <include package="collective.vdexvocabulary" />
   <include package="collective.z3cform.datagridfield" />
   <include package="ftw.upgrade" />

--- a/src/recensio/plone/configure.zcml
+++ b/src/recensio/plone/configure.zcml
@@ -7,6 +7,8 @@
 
   <i18n:registerTranslations directory="locales" />
 
+  <include package="collective.vdexvocabulary" file="meta.zcml" />
+  <include package="collective.vdexvocabulary" />
   <include package="collective.z3cform.datagridfield" />
   <include package="ftw.upgrade" />
 

--- a/src/recensio/plone/vocabularies/configure.zcml
+++ b/src/recensio/plone/vocabularies/configure.zcml
@@ -1,4 +1,8 @@
-<configure xmlns="http://namespaces.zope.org/zope">
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:vdex="http://namespaces.zope.org/vdex">
+
+  <vdex:vocabulary directory="vdex/" />
 
   <utility
       name="recensio.plone.vocabularies.honorifics"

--- a/src/recensio/plone/vocabularies/configure.zcml
+++ b/src/recensio/plone/vocabularies/configure.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:vdex="http://namespaces.zope.org/vdex">
+    xmlns:vdex="http://namespaces.zope.org/vdex"
+    >
 
   <vdex:vocabulary directory="vdex/" />
 

--- a/src/recensio/plone/vocabularies/vdex/ddc_geo.vdex
+++ b/src/recensio/plone/vocabularies/vdex/ddc_geo.vdex
@@ -4,7 +4,7 @@
   <vocabName>
     <langstring language="en">International Standard Classification of Occupations, ISCO-88</langstring>
   </vocabName>
-  <vocabIdentifier>ISCO88</vocabIdentifier>
+  <vocabIdentifier>recensio.plone.vocabularies.region_values</vocabIdentifier>
   <term>
     <termIdentifier>4</termIdentifier>
     <caption>

--- a/src/recensio/plone/vocabularies/vdex/ddc_geo.vdex
+++ b/src/recensio/plone/vocabularies/vdex/ddc_geo.vdex
@@ -1,0 +1,784 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- This document was created with Syntext Serna Free. -->
+<vdex xmlns="http://www.imsglobal.org/xsd/imsvdex_v1p0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsvdex_v1p0                           imsvdex_v1p0.xsd imsvdex_v1p0_thesaurus.xsd                           http://www.imsglobal.org/xsd/imsmd_rootv1p2p1                           imsmd_rootv1p2p1.xsd" orderSignificant="true" profileType="flatTokenTerms" language="en">
+  <vocabName>
+    <langstring language="en">International Standard Classification of Occupations, ISCO-88</langstring>
+  </vocabName>
+  <vocabIdentifier>ISCO88</vocabIdentifier>
+  <term>
+    <termIdentifier>4</termIdentifier>
+    <caption>
+      <langstring language="de">Europa</langstring>
+      <langstring language="en">Europe</langstring>
+      <langstring language="fr">Europe</langstring>
+    </caption>
+    <term>
+      <termIdentifier>41</termIdentifier>
+      <caption>
+        <langstring language="de">Nordeuropa</langstring>
+        <langstring language="en">Northern Europe</langstring>
+        <langstring language="fr">Europe du Nord</langstring>
+      </caption>
+      <term>
+        <termIdentifier>41.1</termIdentifier>
+        <caption>
+          <langstring language="de">Finnland</langstring>
+          <langstring language="en">Finland</langstring>
+          <langstring language="fr">Finlande</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>41.2</termIdentifier>
+        <caption>
+          <langstring language="de">Island</langstring>
+          <langstring language="en">Iceland</langstring>
+          <langstring language="fr">Islande</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>41.3</termIdentifier>
+        <caption>
+          <langstring language="de">Skandinavien</langstring>
+          <langstring language="en">Scandinavia</langstring>
+          <langstring language="fr">Pays scandinaves</langstring>
+        </caption>
+        <term>
+          <termIdentifier>41.31</termIdentifier>
+          <caption>
+            <langstring language="de">Dänemark</langstring>
+            <langstring language="en">Denmark</langstring>
+            <langstring language="fr"> Danemark</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>41.32</termIdentifier>
+          <caption>
+            <langstring language="de">Norwegen</langstring>
+            <langstring language="en">Norway</langstring>
+            <langstring language="fr"> Norvège</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>41.33</termIdentifier>
+          <caption>
+            <langstring language="de">Schweden</langstring>
+            <langstring language="en">Sweden</langstring>
+            <langstring language="fr"> Suède</langstring>
+          </caption>
+        </term>
+      </term>
+      <term>
+        <termIdentifier>41.4</termIdentifier>
+        <caption>
+          <langstring language="de">Baltikum</langstring>
+          <langstring language="en">Baltic states</langstring>
+          <langstring language="fr">Pays baltes</langstring>
+        </caption>
+        <term>
+          <termIdentifier>41.41</termIdentifier>
+          <caption>
+            <langstring language="de">Estland</langstring>
+            <langstring language="en">Estonia</langstring>
+            <langstring language="fr">Estonie</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>41.42</termIdentifier>
+          <caption>
+            <langstring language="de">Lettland</langstring>
+            <langstring language="en">Latvia</langstring>
+            <langstring language="fr"> Lettonie</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>41.43</termIdentifier>
+          <caption>
+            <langstring language="de">Litauen</langstring>
+            <langstring language="en">Lithuania</langstring>
+            <langstring language="fr"> Lituanie</langstring>
+          </caption>
+        </term>
+      </term>
+    </term>
+    <term>
+      <termIdentifier>42</termIdentifier>
+      <caption>
+        <langstring language="de">Westeuropa</langstring>
+        <langstring language="en">Western Europe</langstring>
+        <langstring language="fr">Europe de l&apos;Ouest</langstring>
+      </caption>
+      <term>
+        <termIdentifier>42.1</termIdentifier>
+        <caption>
+          <langstring language="de">Niederlande</langstring>
+          <langstring language="en">Netherlands</langstring>
+          <langstring language="fr">Pays-Bas</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>42.2</termIdentifier>
+        <caption>
+          <langstring language="de">Belgien</langstring>
+          <langstring language="en">Belgium</langstring>
+          <langstring language="fr">Belgique</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>42.3</termIdentifier>
+        <caption>
+          <langstring language="de">Luxemburg</langstring>
+          <langstring language="en">Luxembourg</langstring>
+          <langstring language="fr">Luxembourg</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>42.4</termIdentifier>
+        <caption>
+          <langstring language="de">Frankreich</langstring>
+          <langstring language="en">France</langstring>
+          <langstring language="fr">France</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>42.5</termIdentifier>
+        <caption>
+          <langstring language="de">Deutschland</langstring>
+          <langstring language="en">Germany</langstring>
+          <langstring language="fr">Allemagne</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>42.6</termIdentifier>
+        <caption>
+          <langstring language="de">Österreich</langstring>
+          <langstring language="en">Austria</langstring>
+          <langstring language="fr">Autriche</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>42.7</termIdentifier>
+        <caption>
+          <langstring language="de">Schweiz</langstring>
+          <langstring language="en">Switzerland</langstring>
+          <langstring language="fr">Suisse</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>42.8</termIdentifier>
+        <caption>
+          <langstring language="de">Großbritannien</langstring>
+          <langstring language="en">Great Britain</langstring>
+          <langstring language="fr">Grande-Bretagne</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>42.9</termIdentifier>
+        <caption>
+          <langstring language="de">Irland</langstring>
+          <langstring language="en">Ireland</langstring>
+          <langstring language="fr">Irlande</langstring>
+        </caption>
+      </term>
+    </term>
+    <term>
+      <termIdentifier>43</termIdentifier>
+      <caption>
+        <langstring language="de">Osteuropa</langstring>
+        <langstring language="en">Eastern Europe</langstring>
+        <langstring language="fr">Europe de l&apos;Est</langstring>
+      </caption>
+      <term>
+        <termIdentifier>947.08</termIdentifier>
+        <caption>
+          <langstring language="de">UdSSR und GUS</langstring>
+          <langstring language="en">USSR and CIS</langstring>
+          <langstring language="fr">URSS et CEI</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>43.1</termIdentifier>
+        <caption>
+          <langstring language="de">Russland</langstring>
+          <langstring language="en">Russia</langstring>
+          <langstring language="fr">Russie</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>43.2</termIdentifier>
+        <caption>
+          <langstring language="de">Weißrussland</langstring>
+          <langstring language="en">Belarus</langstring>
+          <langstring language="fr">Biélorussie</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>43.3</termIdentifier>
+        <caption>
+          <langstring language="de">Ukraine</langstring>
+          <langstring language="en">Ukraine</langstring>
+          <langstring language="fr">Ukraine</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>437</termIdentifier>
+        <caption>
+          <langstring language="de">Ostmitteleuropa</langstring>
+          <langstring language="en">East-Central Europe</langstring>
+          <langstring language="fr">Europe médiane</langstring>
+        </caption>
+        <term>
+          <termIdentifier>43.4</termIdentifier>
+          <caption>
+            <langstring language="de">Polen</langstring>
+            <langstring language="en">Poland</langstring>
+            <langstring language="fr">Pologne</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>43.5</termIdentifier>
+          <caption>
+            <langstring language="de">Tschechien</langstring>
+            <langstring language="en">Czech Republic</langstring>
+            <langstring language="fr">République Tchèque</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>43.6</termIdentifier>
+          <caption>
+            <langstring language="de">Slowakei</langstring>
+            <langstring language="en">Slovakia</langstring>
+            <langstring language="fr">Slovaquie</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>43.7</termIdentifier>
+          <caption>
+            <langstring language="de">Ungarn</langstring>
+            <langstring language="en">Hungary</langstring>
+            <langstring language="fr">Hongrie</langstring>
+          </caption>
+        </term>
+      </term>
+      <term>
+        <termIdentifier>43.8</termIdentifier>
+        <caption>
+          <langstring language="de">Rumänien</langstring>
+          <langstring language="en">Romania</langstring>
+          <langstring language="fr">Roumanie</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>43.9</termIdentifier>
+        <caption>
+          <langstring language="de">Moldawien</langstring>
+          <langstring language="en">Moldavia</langstring>
+          <langstring language="fr">Moldavie</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>475</termIdentifier>
+        <caption>
+          <langstring language="de">Kaukasus</langstring>
+          <langstring language="en">Caucasus</langstring>
+          <langstring language="fr">Caucase</langstring>
+          </caption>
+        <term>
+          <termIdentifier>43.10</termIdentifier>
+          <caption>
+            <langstring language="de">Armenien</langstring>
+            <langstring language="en">Armenia</langstring>
+            <langstring language="fr">Arménie</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>43.11</termIdentifier>
+          <caption>
+            <langstring language="de">Aserbaidschan</langstring>
+            <langstring language="en">Azerbaijan</langstring>
+            <langstring language="fr">Azerbaïdjan</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>43.12</termIdentifier>
+          <caption>
+            <langstring language="de">Georgien</langstring>
+            <langstring language="en">Georgia</langstring>
+            <langstring language="fr">Géorgie</langstring>
+          </caption>
+        </term>
+      </term>
+    </term>
+    <term>
+      <termIdentifier>44</termIdentifier>
+      <caption>
+        <langstring language="de">Südeuropa</langstring>
+        <langstring language="en">Southern Europe</langstring>
+        <langstring language="fr">Europe du Sud</langstring>
+      </caption>
+      <term>
+        <termIdentifier>1822</termIdentifier>
+        <caption>
+          <langstring language="de">Mittelmeerraum</langstring>
+          <langstring language="en">Mediterranean region</langstring>
+          <langstring language="fr">Region Méditerranée</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>44.1</termIdentifier>
+        <caption>
+          <langstring language="de">Spanien</langstring>
+          <langstring language="en">Spain</langstring>
+          <langstring language="fr">Espagne</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>44.2</termIdentifier>
+        <caption>
+          <langstring language="de">Portugal</langstring>
+          <langstring language="en">Portugal</langstring>
+          <langstring language="fr">Portugal</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>44.3</termIdentifier>
+        <caption>
+          <langstring language="de">Italien</langstring>
+          <langstring language="en">Italy</langstring>
+          <langstring language="fr">Italie</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>44.4</termIdentifier>
+        <caption>
+          <langstring language="de">Malta</langstring>
+          <langstring language="en">Malta</langstring>
+          <langstring language="fr">Malte</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>44.5</termIdentifier>
+        <caption>
+          <langstring language="de">Zypern</langstring>
+          <langstring language="en">Cyprus</langstring>
+          <langstring language="fr">Chypre</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>44.6</termIdentifier>
+        <caption>
+          <langstring language="de">Südosteuropa</langstring>
+          <langstring language="en">South Eastern Europe</langstring>
+          <langstring language="fr">Europe du Sud-Est</langstring>
+        </caption>
+        <term>
+          <termIdentifier>44.61</termIdentifier>
+          <caption>
+            <langstring language="de">Albanien</langstring>
+            <langstring language="en">Albania</langstring>
+            <langstring language="fr">Albanie</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>44.62</termIdentifier>
+          <caption>
+            <langstring language="de">Bosnien-Herzegowina</langstring>
+            <langstring language="en">Bosnia and Herzegovina</langstring>
+            <langstring language="fr">Bosnie-Herzégovine</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>44.63</termIdentifier>
+          <caption>
+            <langstring language="de">Bulgarien</langstring>
+            <langstring language="en">Bulgaria</langstring>
+            <langstring language="fr">Bulgarie</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>44.64</termIdentifier>
+          <caption>
+            <langstring language="de">Griechenland</langstring>
+            <langstring language="en">Greece</langstring>
+            <langstring language="fr">Grèce</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>44.65</termIdentifier>
+          <caption>
+            <langstring language="de">Kroatien</langstring>
+            <langstring language="en">Croatia</langstring>
+            <langstring language="fr">Croatie</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>44.66</termIdentifier>
+          <caption>
+            <langstring language="de">Makedonien</langstring>
+            <langstring language="en">Macedonia</langstring>
+            <langstring language="fr">Macédoine</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>44.67</termIdentifier>
+          <caption>
+            <langstring language="de">Serbien</langstring>
+            <langstring language="en">Serbia</langstring>
+            <langstring language="fr">Serbie</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>44.68</termIdentifier>
+          <caption>
+            <langstring language="de">Montenegro</langstring>
+            <langstring language="en">Montenegro</langstring>
+            <langstring language="fr">Monténégro</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>44.69</termIdentifier>
+          <caption>
+            <langstring language="de">Slowenien</langstring>
+            <langstring language="en">Slovenia</langstring>
+            <langstring language="fr">Slovénie</langstring>
+          </caption>
+        </term>
+		<term>
+		  <termIdentifier>561</termIdentifier>
+		  <caption>
+			<langstring language="de">Türkei, Osmanisches Reich</langstring>
+			<langstring language="en">Turkey, Ottoman Empire</langstring>
+			<langstring language="fr">Turquie, Empire ottoman</langstring>
+		  </caption>
+		</term>
+        <term>
+          <termIdentifier>44.71</termIdentifier>
+          <caption>
+            <langstring language="de">Kosovo</langstring>
+            <langstring language="en">Kosovo</langstring>
+            <langstring language="fr">Kosovo</langstring>
+          </caption>
+        </term>
+      </term>
+    </term>
+  </term>
+  <term>
+    <termIdentifier>5</termIdentifier>
+    <caption>
+      <langstring language="de">Asien</langstring>
+      <langstring language="en">Asia</langstring>
+      <langstring language="fr">Asie</langstring>
+    </caption>
+    <term>
+      <termIdentifier>59.2</termIdentifier>
+      <caption>
+        <langstring language="de">Arabische Halbinsel und benachbarte Gebiete</langstring>
+        <langstring language="en">Arabian Peninsula and neighbouring territories</langstring>
+        <langstring language="fr">Arabie et territoires voisins</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>51</termIdentifier>
+      <caption>
+        <langstring language="de">China und benachbarte Gebiete</langstring>
+        <langstring language="en">China and neighbouring territories</langstring>
+        <langstring language="fr">Chine et territoires voisins</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>567</termIdentifier>
+      <caption>
+        <langstring language="de">Irak</langstring>
+        <langstring language="en">Iraq</langstring>
+        <langstring language="fr">Irak</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>55</termIdentifier>
+      <caption>
+        <langstring language="de">Iran</langstring>
+        <langstring language="en">Iran</langstring>
+        <langstring language="fr">Iran</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>52</termIdentifier>
+      <caption>
+        <langstring language="de">Japan</langstring>
+        <langstring language="en">Japan</langstring>
+        <langstring language="fr">Japon</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>56</termIdentifier>
+      <caption>
+        <langstring language="de">Naher Osten</langstring>
+        <langstring language="en">Near East</langstring>
+        <langstring language="fr">Proche-Orient</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>59.1</termIdentifier>
+      <caption>
+        <langstring language="de">Palästina, Israel</langstring>
+        <langstring language="en">Palestine, Israel</langstring>
+        <langstring language="fr">Palestine, Israël</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>57</termIdentifier>
+      <caption>
+        <langstring language="de">Sibirien</langstring>
+        <langstring language="en">Sibiria</langstring>
+        <langstring language="fr">Sibérie</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>54</termIdentifier>
+      <caption>
+        <langstring language="de">Südasien u. Indien</langstring>
+        <langstring language="en">Southern Asia and India</langstring>
+        <langstring language="fr">Asie du Sud et Inde</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>59</termIdentifier>
+      <caption>
+        <langstring language="de">Südostasien</langstring>
+        <langstring language="en">South-Eastern Asia</langstring>
+        <langstring language="fr">Asie du Sud-Est</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>58</termIdentifier>
+      <caption>
+        <langstring language="de">Zentralasien</langstring>
+        <langstring language="en">Central Asia</langstring>
+        <langstring language="fr">Asie centrale</langstring>
+      </caption>
+    </term>
+  </term>
+  <term>
+    <termIdentifier>6</termIdentifier>
+    <caption>
+      <langstring language="de">Afrika</langstring>
+      <langstring language="en">Africa</langstring>
+      <langstring language="fr">Afrique</langstring>
+    </caption>
+    <term>
+      <termIdentifier>61</termIdentifier>
+      <caption>
+        <langstring language="de">Tunesien und Libyen</langstring>
+        <langstring language="en">Tunisia and Libya</langstring>
+        <langstring language="fr">Tunisie et Libye</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>62</termIdentifier>
+      <caption>
+        <langstring language="de">Ägypten und Sudan</langstring>
+        <langstring language="en">Egypt and Sudan</langstring>
+        <langstring language="fr">Égypte et Soudan</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>63</termIdentifier>
+      <caption>
+        <langstring language="de">Äthiopien und Eritrea</langstring>
+        <langstring language="en">Ethiopia and Eritrea</langstring>
+        <langstring language="fr">Éthiopie et Érythrée</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>64</termIdentifier>
+      <caption>
+        <langstring language="de">Marokko</langstring>
+        <langstring language="en">Morocco</langstring>
+        <langstring language="fr">Maroc</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>65</termIdentifier>
+      <caption>
+        <langstring language="de">Algerien</langstring>
+        <langstring language="en">Algeria</langstring>
+        <langstring language="fr">Algérie</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>66</termIdentifier>
+      <caption>
+        <langstring language="de">Westafrika</langstring>
+        <langstring language="en">Western Africa</langstring>
+        <langstring language="fr">Afrique de l&apos;Ouest</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>67</termIdentifier>
+      <caption>
+        <langstring language="de">Zentral- u. Ostafrika</langstring>
+        <langstring language="en">Middle and Eastern Africa</langstring>
+        <langstring language="fr">Afrique de l&apos; Est et centrale</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>68</termIdentifier>
+      <caption>
+        <langstring language="de">Südafrika</langstring>
+        <langstring language="en">Southern Africa</langstring>
+        <langstring language="fr">Afrique australe</langstring>
+      </caption>
+    </term>
+  </term>
+  <term>
+    <termIdentifier>7</termIdentifier>
+    <caption>
+      <langstring language="de">Amerika</langstring>
+      <langstring language="en">America</langstring>
+      <langstring language="fr">Amérique</langstring>
+    </caption>
+    <term>
+      <termIdentifier>71</termIdentifier>
+      <caption>
+        <langstring language="de">Nordamerika</langstring>
+        <langstring language="en">North America</langstring>
+        <langstring language="fr">Amérique du Nord</langstring>
+      </caption>
+      <term>
+        <termIdentifier>71.1</termIdentifier>
+        <caption>
+          <langstring language="de"> USA</langstring>
+          <langstring language="en"> USA</langstring>
+          <langstring language="fr">États-Unis</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>71.2</termIdentifier>
+        <caption>
+          <langstring language="de"> Kanada</langstring>
+          <langstring language="en"> Canada</langstring>
+          <langstring language="fr">Canada</langstring>
+        </caption>
+      </term>
+    </term>
+    <term>
+      <termIdentifier>72</termIdentifier>
+      <caption>
+        <langstring language="de">Mittelamerika</langstring>
+        <langstring language="en">Central America</langstring>
+        <langstring language="fr">Amérique centrale</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>73</termIdentifier>
+      <caption>
+        <langstring language="de">Südamerika</langstring>
+        <langstring language="en">South America</langstring>
+        <langstring language="fr">Amérique du Sud</langstring>
+      </caption>
+    </term>
+  </term>
+  <term>
+    <termIdentifier>11</termIdentifier>
+    <caption>
+      <langstring language="de">Kalte Klimazonen</langstring>
+      <langstring language="en">Cold climates</langstring>
+      <langstring language="fr">Climats froids</langstring>
+    </caption>
+  </term>
+  <term>
+    <termIdentifier>9</termIdentifier>
+    <caption>
+      <langstring language="de">Andere Teile der Welt</langstring>
+      <langstring language="en">Other countries</langstring>
+      <langstring language="fr">Autres pays</langstring>
+    </caption>
+  </term>
+  <term>
+    <termIdentifier>181</termIdentifier>
+    <caption>
+      <langstring language="de">Welt</langstring>
+      <langstring language="en">World</langstring>
+      <langstring language="fr">Monde</langstring>
+    </caption>
+  </term>
+  <term>
+    <termIdentifier>3</termIdentifier>
+    <caption>
+      <langstring language="de">Alte Welt</langstring>
+      <langstring language="en">Ancient World</langstring>
+      <langstring language="fr">Ancien Monde</langstring>
+    </caption>
+    <term>
+      <termIdentifier>32</termIdentifier>
+      <caption>
+        <langstring language="de">Ägypten / Alte Welt</langstring>
+        <langstring language="en">Egypt / ancient</langstring>
+        <langstring language="fr">Égypte / Ancien Monde</langstring>
+      </caption>
+    </term>
+	<term>
+	  <termIdentifier>398</termIdentifier>
+	  <caption>
+		<langstring language="de">Südosteuropa, Byzanz / Alte Welt</langstring>
+		<langstring language="en">South Eastern Europe, Byzantine Empire / ancient</langstring>
+		<langstring language="fr">Europe du Sud-Est, Empire </langstring>
+	  </caption>
+	</term>
+    <term>
+      <termIdentifier>31</termIdentifier>
+      <caption>
+        <langstring language="de">China / Alte Welt</langstring>
+        <langstring language="en">China / ancient</langstring>
+        <langstring language="fr">Chine / Ancien Monde</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>38</termIdentifier>
+      <caption>
+        <langstring language="de">Griechenland / Alte Welt</langstring>
+        <langstring language="en">Greece / ancient</langstring>
+        <langstring language="fr">Grèce / Ancien Monde</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>35</termIdentifier>
+      <caption>
+        <langstring language="de">Mesopotamien, Persien / Alte Welt</langstring>
+        <langstring language="en">Mesopotamia, Persia / ancient</langstring>
+        <langstring language="fr">Mésopotamie, Perse / Ancien Monde</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>394</termIdentifier>
+      <caption>
+        <langstring language="de">Naher Osten / Alte Welt</langstring>
+        <langstring language="en">Near East / ancient</langstring>
+        <langstring language="fr">Proche-Orient / Ancient Monde</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>33</termIdentifier>
+      <caption>
+        <langstring language="de">Palästina, Israel / Alte Welt</langstring>
+        <langstring language="en">Palestine, Israel / ancient</langstring>
+        <langstring language="fr">Palestine, Israël / Ancien Monde</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>37</termIdentifier>
+      <caption>
+        <langstring language="de">Römisches Reich</langstring>
+        <langstring language="en">Roman Empire</langstring>
+        <langstring language="fr">Empire romain</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>39</termIdentifier>
+      <caption>
+        <langstring language="de">Andere Teile der alten Welt</langstring>
+        <langstring language="en">Other parts of the world</langstring>
+        <langstring language="fr">Autres parties du monde</langstring>
+      </caption>
+    </term>
+  </term>
+</vdex>

--- a/src/recensio/plone/vocabularies/vdex/ddc_geo_bsb.vdex
+++ b/src/recensio/plone/vocabularies/vdex/ddc_geo_bsb.vdex
@@ -1,0 +1,687 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<vdex xmlns="http://www.imsglobal.org/xsd/imsvdex_v1p0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsvdex_v1p0                           imsvdex_v1p0.xsd imsvdex_v1p0_thesaurus.xsd                           http://www.imsglobal.org/xsd/imsmd_rootv1p2p1                           imsmd_rootv1p2p1.xsd" orderSignificant="true" profileType="flatTokenTerms" language="en">
+  <vocabName>
+    <langstring language="en">International Standard Classification of Occupations, ISCO-88</langstring>
+  </vocabName>
+  <vocabIdentifier>ISCO88</vocabIdentifier>
+  <term>
+    <termIdentifier>4</termIdentifier>
+    <caption>
+      <langstring language="de">Europa</langstring>
+      <langstring language="en">Europe</langstring>
+      <langstring language="fr">Europe</langstring>
+    </caption>
+    <term>
+      <termIdentifier>48</termIdentifier>
+      <caption>
+        <langstring language="de">Nordeuropa</langstring>
+        <langstring language="en">Northern Europe</langstring>
+        <langstring language="fr">Europe du Nord</langstring>
+      </caption>
+      <term>
+        <termIdentifier>4897</termIdentifier>
+        <caption>
+          <langstring language="de">Finnland</langstring>
+          <langstring language="en">Finland</langstring>
+          <langstring language="fr">Finlande</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>4912</termIdentifier>
+        <caption>
+          <langstring language="de">Island</langstring>
+          <langstring language="en">Iceland</langstring>
+          <langstring language="fr">Islande</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>48</termIdentifier>
+        <caption>
+          <langstring language="de">Skandinavien</langstring>
+          <langstring language="en">Scandinavia</langstring>
+          <langstring language="fr">Pays scandinaves</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>479</termIdentifier>
+        <caption>
+          <langstring language="de">Baltikum</langstring>
+          <langstring language="en">Baltic states</langstring>
+          <langstring language="fr">Pays baltes</langstring>
+        </caption>
+        <term>
+          <termIdentifier>4798</termIdentifier>
+          <caption>
+            <langstring language="de">Estland</langstring>
+            <langstring language="en">Estonia</langstring>
+            <langstring language="fr">Estonie</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>4796</termIdentifier>
+          <caption>
+            <langstring language="de">Lettland</langstring>
+            <langstring language="en">Latvia</langstring>
+            <langstring language="fr"> Lettonie</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>4793</termIdentifier>
+          <caption>
+            <langstring language="de">Litauen</langstring>
+            <langstring language="en">Lithuania</langstring>
+            <langstring language="fr"> Lituanie</langstring>
+          </caption>
+        </term>
+      </term>
+    </term>
+    <term>
+      <termIdentifier>991</termIdentifier>
+      <caption>
+        <langstring language="de">Westeuropa</langstring>
+        <langstring language="en">Western Europe</langstring>
+        <langstring language="fr">Europe de l'Ouest</langstring>
+      </caption>
+      <term>
+        <termIdentifier>492</termIdentifier>
+        <caption>
+          <langstring language="de">Niederlande</langstring>
+          <langstring language="en">Netherlands</langstring>
+          <langstring language="fr">Pays-Bas</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>493</termIdentifier>
+        <caption>
+          <langstring language="de">Belgien</langstring>
+          <langstring language="en">Belgium</langstring>
+          <langstring language="fr">Belgique</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>493</termIdentifier>
+        <caption>
+          <langstring language="de">Luxemburg</langstring>
+          <langstring language="en">Luxembourg</langstring>
+          <langstring language="fr">Luxembourg</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>44</termIdentifier>
+        <caption>
+          <langstring language="de">Frankreich</langstring>
+          <langstring language="en">France</langstring>
+          <langstring language="fr">France</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>43</termIdentifier>
+        <caption>
+          <langstring language="de">Deutschland</langstring>
+          <langstring language="en">Germany</langstring>
+          <langstring language="fr">Allemagne</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>436</termIdentifier>
+        <caption>
+          <langstring language="de">&#214;sterreich</langstring>
+          <langstring language="en">Austria</langstring>
+          <langstring language="fr">Autriche</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>494</termIdentifier>
+        <caption>
+          <langstring language="de">Schweiz</langstring>
+          <langstring language="en">Switzerland</langstring>
+          <langstring language="fr">Suisse</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>41</termIdentifier>
+        <caption>
+          <langstring language="de">Gro&#223;britannien</langstring>
+          <langstring language="en">Great Britain</langstring>
+          <langstring language="fr">Grande-Bretagne</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>415</termIdentifier>
+        <caption>
+          <langstring language="de">Irland</langstring>
+          <langstring language="en">Ireland</langstring>
+          <langstring language="fr">Irlande</langstring>
+        </caption>
+      </term>
+    </term>
+    <term>
+      <termIdentifier>47</termIdentifier>
+      <caption>
+        <langstring language="de">Osteuropa</langstring>
+        <langstring language="en">Eastern Europe</langstring>
+        <langstring language="fr">Europe de l'Est</langstring>
+      </caption>
+      <term>
+        <termIdentifier>471</termIdentifier>
+        <caption>
+          <langstring language="de">Russland</langstring>
+          <langstring language="en">Russia</langstring>
+          <langstring language="fr">Russie</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>478</termIdentifier>
+        <caption>
+          <langstring language="de">Wei&#223;russland</langstring>
+          <langstring language="en">Belarus</langstring>
+          <langstring language="fr">Bi&#233;lorussie</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>477</termIdentifier>
+        <caption>
+          <langstring language="de">Ukraine</langstring>
+          <langstring language="en">Ukraine</langstring>
+          <langstring language="fr">Ukraine</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>438</termIdentifier>
+        <caption>
+          <langstring language="de">Polen</langstring>
+          <langstring language="en">Poland</langstring>
+          <langstring language="fr">Pologne</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>4371</termIdentifier>
+        <caption>
+          <langstring language="de">Tschechien</langstring>
+          <langstring language="en">Czech Republic</langstring>
+          <langstring language="fr">R&#233;publique Tch&#232;que</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>4373</termIdentifier>
+        <caption>
+          <langstring language="de">Slowakei</langstring>
+          <langstring language="en">Slovakia</langstring>
+          <langstring language="fr">Slovaquie</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>439</termIdentifier>
+        <caption>
+          <langstring language="de">Ungarn</langstring>
+          <langstring language="en">Hungary</langstring>
+          <langstring language="fr">Hongrie</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>498</termIdentifier>
+        <caption>
+          <langstring language="de">Rum&#228;nien</langstring>
+          <langstring language="en">Romania</langstring>
+          <langstring language="fr">Roumanie</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>476</termIdentifier>
+        <caption>
+          <langstring language="de">Moldawien</langstring>
+          <langstring language="en">Moldavia</langstring>
+          <langstring language="fr">Moldavie</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>4756</termIdentifier>
+        <caption>
+          <langstring language="de">Armenien</langstring>
+          <langstring language="en">Armenia</langstring>
+          <langstring language="fr">Arm&#233;nie</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>4754</termIdentifier>
+        <caption>
+          <langstring language="de">Aserbaidschan</langstring>
+          <langstring language="en">Azerbaijan</langstring>
+          <langstring language="fr">Azerba&#239;djan</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>4758</termIdentifier>
+        <caption>
+          <langstring language="de">Georgien</langstring>
+          <langstring language="en">Georgia</langstring>
+          <langstring language="fr">G&#233;orgie</langstring>
+        </caption>
+      </term>
+    </term>
+    <term>
+      <termIdentifier>992</termIdentifier>
+      <caption>
+        <langstring language="de">S&#252;deuropa</langstring>
+        <langstring language="en">Southern Europe</langstring>
+        <langstring language="fr">Europe du Sud</langstring>
+      </caption>
+      <term>
+        <termIdentifier>46</termIdentifier>
+        <caption>
+          <langstring language="de">Spanien</langstring>
+          <langstring language="en">Spain</langstring>
+          <langstring language="fr">Espagne</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>469</termIdentifier>
+        <caption>
+          <langstring language="de">Portugal</langstring>
+          <langstring language="en">Portugal</langstring>
+          <langstring language="fr">Portugal</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>45</termIdentifier>
+        <caption>
+          <langstring language="de">Italien</langstring>
+          <langstring language="en">Italy</langstring>
+          <langstring language="fr">Italie</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>4585</termIdentifier>
+        <caption>
+          <langstring language="de">Malta</langstring>
+          <langstring language="en">Malta</langstring>
+          <langstring language="fr">Malte</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>5693</termIdentifier>
+        <caption>
+          <langstring language="de">Zypern</langstring>
+          <langstring language="en">Cyprus</langstring>
+          <langstring language="fr">Chypre</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>993</termIdentifier>
+        <caption>
+          <langstring language="de">S&#252;dosteuropa</langstring>
+          <langstring language="en">South Eastern Europe</langstring>
+          <langstring language="fr">Europe du Sud-Est</langstring>
+        </caption>
+        <term>
+          <termIdentifier>4965</termIdentifier>
+          <caption>
+            <langstring language="de">Albanien</langstring>
+            <langstring language="en">Albania</langstring>
+            <langstring language="fr">Albanie</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>49742</termIdentifier>
+          <caption>
+            <langstring language="de">Bosnien-Herzegowina</langstring>
+            <langstring language="en">Bosnia and Herzegovina</langstring>
+            <langstring language="fr">Bosnie-Herz&#233;govine</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>499</termIdentifier>
+          <caption>
+            <langstring language="de">Bulgarien</langstring>
+            <langstring language="en">Bulgaria</langstring>
+            <langstring language="fr">Bulgarie</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>495</termIdentifier>
+          <caption>
+            <langstring language="de">Griechenland</langstring>
+            <langstring language="en">Greece</langstring>
+            <langstring language="fr">Gr&#232;ce</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>4972</termIdentifier>
+          <caption>
+            <langstring language="de">Kroatien</langstring>
+            <langstring language="en">Croatia</langstring>
+            <langstring language="fr">Croatie</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>4976</termIdentifier>
+          <caption>
+            <langstring language="de">Makedonien</langstring>
+            <langstring language="en">Macedonia</langstring>
+            <langstring language="fr">Mac&#233;doine</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>4971</termIdentifier>
+          <caption>
+            <langstring language="de">Serbien</langstring>
+            <langstring language="en">Serbia</langstring>
+            <langstring language="fr">Serbie</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>49745</termIdentifier>
+          <caption>
+            <langstring language="de">Montenegro</langstring>
+            <langstring language="en">Montenegro</langstring>
+            <langstring language="fr">Mont&#233;n&#233;gro</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>4973</termIdentifier>
+          <caption>
+            <langstring language="de">Slowenien</langstring>
+            <langstring language="en">Slovenia</langstring>
+            <langstring language="fr">Slov&#233;nie</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>561</termIdentifier>
+          <caption>
+            <langstring language="de">T&#252;rkei</langstring>
+            <langstring language="en">Turkey</langstring>
+            <langstring language="fr">Turquie</langstring>
+          </caption>
+        </term>
+        <term>
+          <termIdentifier>4975</termIdentifier>
+          <caption>
+            <langstring language="de">Kosovo</langstring>
+            <langstring language="en">Kosovo</langstring>
+            <langstring language="fr">Kosovo</langstring>
+          </caption>
+        </term>
+      </term>
+    </term>
+  </term>
+  <term>
+    <termIdentifier>5</termIdentifier>
+    <caption>
+      <langstring language="de">Asien</langstring>
+      <langstring language="en">Asia</langstring>
+      <langstring language="fr">Asie</langstring>
+    </caption>
+    <term>
+      <termIdentifier>51</termIdentifier>
+      <caption>
+        <langstring language="de">China und benachbarte Gebiete</langstring>
+        <langstring language="en">China and neighbouring territories</langstring>
+        <langstring language="fr">Chine et territoires voisins</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>52</termIdentifier>
+      <caption>
+        <langstring language="de">Japan</langstring>
+        <langstring language="en">Japan</langstring>
+        <langstring language="fr">Japon</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>54</termIdentifier>
+      <caption>
+        <langstring language="de">S&#252;dasien u. Indien</langstring>
+        <langstring language="en">Southern Asia and India</langstring>
+        <langstring language="fr">Asie du Sud et Inde</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>56</termIdentifier>
+      <caption>
+        <langstring language="de">Naher Osten</langstring>
+        <langstring language="en">Near East</langstring>
+        <langstring language="fr">Proche-Orient</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>53</termIdentifier>
+      <caption>
+        <langstring language="de">Arabische Halbinsel und benachbarte Gebiete</langstring>
+        <langstring language="en">Arabian Peninsula and neighbouring territories</langstring>
+        <langstring language="fr">Arabie et territoires voisins</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>5694</termIdentifier>
+      <caption>
+        <langstring language="de">Israel, Pal&#228;stina</langstring>
+        <langstring language="en">Israel, Palestine</langstring>
+        <langstring language="fr">Isra&#235;l, Palestine</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>57</termIdentifier>
+      <caption>
+        <langstring language="de">Sibirien</langstring>
+        <langstring language="en">Sibiria</langstring>
+        <langstring language="fr">Sib&#233;rie</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>58</termIdentifier>
+      <caption>
+        <langstring language="de">Zentralasien</langstring>
+        <langstring language="en">Central Asia</langstring>
+        <langstring language="fr">Asie centrale</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>59</termIdentifier>
+      <caption>
+        <langstring language="de">S&#252;dostasien</langstring>
+        <langstring language="en">South-Eastern Asia</langstring>
+        <langstring language="fr">Asie du Sud-Est</langstring>
+      </caption>
+    </term>
+  </term>
+  <term>
+    <termIdentifier>6</termIdentifier>
+    <caption>
+      <langstring language="de">Afrika</langstring>
+      <langstring language="en">Africa</langstring>
+      <langstring language="fr">Afrique</langstring>
+    </caption>
+    <term>
+      <termIdentifier>61</termIdentifier>
+      <caption>
+        <langstring language="de">Tunesien und Libyen</langstring>
+        <langstring language="en">Tunisia and Libya</langstring>
+        <langstring language="fr">Tunisie et Libye</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>62</termIdentifier>
+      <caption>
+        <langstring language="de">&#196;gypten und Sudan</langstring>
+        <langstring language="en">Egypt and Sudan</langstring>
+        <langstring language="fr">&#201;gypte et Soudan</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>63</termIdentifier>
+      <caption>
+        <langstring language="de">&#196;thiopien und Eritrea</langstring>
+        <langstring language="en">Ethiopia and Eritrea</langstring>
+        <langstring language="fr">&#201;thiopie et &#201;rythr&#233;e</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>64</termIdentifier>
+      <caption>
+        <langstring language="de">Marokko</langstring>
+        <langstring language="en">Morocco</langstring>
+        <langstring language="fr">Maroc</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>65</termIdentifier>
+      <caption>
+        <langstring language="de">Algerien</langstring>
+        <langstring language="en">Algeria</langstring>
+        <langstring language="fr">Alg&#233;rie</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>66</termIdentifier>
+      <caption>
+        <langstring language="de">Westafrika</langstring>
+        <langstring language="en">Western Africa</langstring>
+        <langstring language="fr">Afrique de l'Ouest</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>67</termIdentifier>
+      <caption>
+        <langstring language="de">Zentral- u. Ostafrika</langstring>
+        <langstring language="en">Middle and Eastern Africa</langstring>
+        <langstring language="fr">Afrique de l' Est et centrale</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>68</termIdentifier>
+      <caption>
+        <langstring language="de">S&#252;dafrika</langstring>
+        <langstring language="en">Southern Africa</langstring>
+        <langstring language="fr">Afrique australe</langstring>
+      </caption>
+    </term>
+  </term>
+  <term>
+    <termIdentifier>7</termIdentifier>
+    <caption>
+      <langstring language="de">Amerika</langstring>
+      <langstring language="en">America</langstring>
+      <langstring language="fr">Am&#233;rique</langstring>
+    </caption>
+    <term>
+      <termIdentifier>7</termIdentifier>
+      <caption>
+        <langstring language="de">Nordamerika</langstring>
+        <langstring language="en">North America</langstring>
+        <langstring language="fr">Am&#233;rique du Nord</langstring>
+      </caption>
+      <term>
+        <termIdentifier>73</termIdentifier>
+        <caption>
+          <langstring language="de"> USA</langstring>
+          <langstring language="en"> USA</langstring>
+          <langstring language="fr">&#201;tats-Unis</langstring>
+        </caption>
+      </term>
+      <term>
+        <termIdentifier>71</termIdentifier>
+        <caption>
+          <langstring language="de"> Kanada</langstring>
+          <langstring language="en"> Canada</langstring>
+          <langstring language="fr">Canada</langstring>
+        </caption>
+      </term>
+    </term>
+    <term>
+      <termIdentifier>72</termIdentifier>
+      <caption>
+        <langstring language="de">Mittelamerika</langstring>
+        <langstring language="en">Central America</langstring>
+        <langstring language="fr">Am&#233;rique centrale</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>8</termIdentifier>
+      <caption>
+        <langstring language="de">S&#252;damerika</langstring>
+        <langstring language="en">South America</langstring>
+        <langstring language="fr">Am&#233;rique du Sud</langstring>
+      </caption>
+    </term>
+  </term>
+  <term>
+    <termIdentifier>9</termIdentifier>
+    <caption>
+      <langstring language="de">Andere Teile der Welt</langstring>
+      <langstring language="en">Other countries</langstring>
+      <langstring language="fr">Autres pays</langstring>
+    </caption>
+  </term>
+  <term>
+    <termIdentifier>181</termIdentifier>
+    <caption>
+      <langstring language="de">Weltgeschichte</langstring>
+      <langstring language="en">Global History</langstring>
+      <langstring language="fr">Histoire globale</langstring>
+    </caption>
+  </term>
+  <term>
+    <termIdentifier>3</termIdentifier>
+    <caption>
+      <langstring language="de">Alte Welt</langstring>
+      <langstring language="en">Ancient World</langstring>
+      <langstring language="fr">Ancien Monde</langstring>
+    </caption>
+    <term>
+      <termIdentifier>32</termIdentifier>
+      <caption>
+        <langstring language="de">&#196;gypten / Alte Welt</langstring>
+        <langstring language="en">Egypt / ancient</langstring>
+        <langstring language="fr">&#201;gypte / Ancien Monde</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>398</termIdentifier>
+      <caption>
+        <langstring language="de">S&#252;dosteuropa / Alte Welt</langstring>
+        <langstring language="en">South Eastern Europe / ancient</langstring>
+        <langstring language="fr">Europe du Sud-Est / Ancien Monde</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>31</termIdentifier>
+      <caption>
+        <langstring language="de">China / Alte Welt</langstring>
+        <langstring language="en">China / ancient</langstring>
+        <langstring language="fr">Chine / Ancien Monde</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>38</termIdentifier>
+      <caption>
+        <langstring language="de">Griechenland / Alte Welt</langstring>
+        <langstring language="en">Greece / ancient</langstring>
+        <langstring language="fr">Gr&#232;ce / Ancien Monde</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>35</termIdentifier>
+      <caption>
+        <langstring language="de">Mesopotamien, Persien / Alte Welt</langstring>
+        <langstring language="en">Mesopotamia, Persia / ancient</langstring>
+        <langstring language="fr">M&#233;sopotamie, Perse / Ancien Monde</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>33</termIdentifier>
+      <caption>
+        <langstring language="de">Pal&#228;stina, Israel / Alte Welt</langstring>
+        <langstring language="en">Palestine, Israel / ancient</langstring>
+        <langstring language="fr">Palestine, Isra&#235;l / Ancien Monde</langstring>
+      </caption>
+    </term>
+    <term>
+      <termIdentifier>37</termIdentifier>
+      <caption>
+        <langstring language="de">R&#246;misches Reich</langstring>
+        <langstring language="en">Roman Empire</langstring>
+        <langstring language="fr">Empire romain</langstring>
+      </caption>
+    </term>
+  </term>
+</vdex>

--- a/src/recensio/plone/vocabularies/vdex/ddc_geo_bsb.vdex
+++ b/src/recensio/plone/vocabularies/vdex/ddc_geo_bsb.vdex
@@ -3,7 +3,7 @@
   <vocabName>
     <langstring language="en">International Standard Classification of Occupations, ISCO-88</langstring>
   </vocabName>
-  <vocabIdentifier>ISCO88</vocabIdentifier>
+  <vocabIdentifier>recensio.plone.vocabularies.region_values_bsb</vocabIdentifier>
   <term>
     <termIdentifier>4</termIdentifier>
     <caption>

--- a/src/recensio/plone/vocabularies/vdex/ddc_sach.vdex
+++ b/src/recensio/plone/vocabularies/vdex/ddc_sach.vdex
@@ -11,7 +11,7 @@
   <vocabName>
       <langstring language="en">International Standard Classification of Occupations, ISCO-88</langstring>
   </vocabName>
-  <vocabIdentifier>ISCO88</vocabIdentifier>
+  <vocabIdentifier>recensio.plone.vocabularies.topic_values</vocabIdentifier>
 
   <term>
     <termIdentifier>630.9</termIdentifier>

--- a/src/recensio/plone/vocabularies/vdex/ddc_sach.vdex
+++ b/src/recensio/plone/vocabularies/vdex/ddc_sach.vdex
@@ -1,0 +1,358 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vdex xmlns="http://www.imsglobal.org/xsd/imsvdex_v1p0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.imsglobal.org/xsd/imsvdex_v1p0
+                          imsvdex_v1p0.xsd imsvdex_v1p0_thesaurus.xsd
+                          http://www.imsglobal.org/xsd/imsmd_rootv1p2p1
+                          imsmd_rootv1p2p1.xsd"
+      orderSignificant="true"
+      profileType="flatTokenTerms"
+      language="en">
+  <vocabName>
+      <langstring language="en">International Standard Classification of Occupations, ISCO-88</langstring>
+  </vocabName>
+  <vocabIdentifier>ISCO88</vocabIdentifier>
+
+  <term>
+    <termIdentifier>630.9</termIdentifier>
+    <caption>
+      <langstring language="de">Agrargeschichte</langstring>
+      <langstring language="en">History of agriculture</langstring>
+      <langstring language="fr">Histoire rurale</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>930.1</termIdentifier>
+    <caption>
+      <langstring language="de">Archäologie</langstring>
+      <langstring language="en">Archaeology</langstring>
+      <langstring language="fr">Archéologie</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>020</termIdentifier>
+    <caption>
+      <langstring language="de">Archiv, Bibliothek, Museum</langstring>
+      <langstring language="en">Archive, Library, Museum</langstring>
+      <langstring language="fr">Archives, Bibliothèque, Musée</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>370.9</termIdentifier>
+    <caption>
+      <langstring language="de">Bildungs-, Wissenschafts-, Schul- und Universitätsgeschichte</langstring>
+      <langstring language="en">History of education</langstring>
+      <langstring language="fr">Histoire de l'éducation</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>929</termIdentifier>
+    <caption>
+      <langstring language="de">Biographien, Familiengeschichte</langstring>
+      <langstring language="en">Biographies, genealogy</langstring>
+      <langstring language="fr">Biographies, généalogie</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>791.409</termIdentifier>
+    <caption>
+      <langstring language="de">Film-, Hörfunk- und Fernsehgeschichte </langstring>
+      <langstring language="en">History of cinema, radio and television</langstring>
+      <langstring language="fr">Histoire du cinéma, de la radio et de la télévision</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>900</termIdentifier>
+    <caption>
+      <langstring language="de">Geschichte allgemein</langstring>
+      <langstring language="en">History</langstring>
+      <langstring language="fr">Histoire générale</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>509</termIdentifier>
+    <caption>
+      <langstring language="de">Geschichte der Naturwissenschaften</langstring>
+      <langstring language="en">History of science</langstring>
+      <langstring language="fr">Histoire des sciences</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>150.9</termIdentifier>
+    <caption>
+      <langstring language="de">Geschichte der Psychologie</langstring>
+      <langstring language="en">History of psychology</langstring>
+      <langstring language="fr">Histoire de la psychologie</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>909.0491497</termIdentifier>
+    <caption>
+      <langstring language="de">Geschichte der Sinti und Roma</langstring>
+      <langstring language="en">History of Sinti and Romanies</langstring>
+      <langstring language="fr">Histoire des Sinti et des Roms</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>070.9</termIdentifier>
+    <caption>
+      <langstring language="de">Geschichte des Journalismus, der Medien und der Kommunikation</langstring>
+      <langstring language="en">History of journalism, media and communication</langstring>
+      <langstring language="fr">Histoire du journalisme, des médias et de la communication</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>907.1</termIdentifier>
+    <caption>
+      <langstring language="de">Geschichtsdidaktik</langstring>
+      <langstring language="en">History Didactics</langstring>
+      <langstring language="fr">Didactique de l'histoire</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>305.309</termIdentifier>
+    <caption>
+      <langstring language="de">Geschlechtergeschichte</langstring>
+      <langstring language="en">Gender Studies</langstring>
+      <langstring language="fr">Histoire des genres</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>880</termIdentifier>
+    <caption>
+      <langstring language="de">Griechische Literatur</langstring>
+      <langstring language="en">Greek Literature</langstring>
+      <langstring language="fr">Littérature grecque</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>304.609</termIdentifier>
+    <caption>
+      <langstring language="de">Historische Demographie</langstring>
+      <langstring language="en">Historical Demography</langstring>
+      <langstring language="fr">Démographie</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>911</termIdentifier>
+    <caption>
+      <langstring language="de">Historische Geographie</langstring>
+      <langstring language="en">Historical Geography</langstring>
+      <langstring language="fr">Géographie historique</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>907.2</termIdentifier>
+    <caption>
+      <langstring language="de">Historische Hilfswissenschaften</langstring>
+      <langstring language="en">Auxiliary sciences of history</langstring>
+      <langstring language="fr">Sciences auxiliaires de l'Histoire</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>001.09</termIdentifier>
+    <caption>
+      <langstring language="de">Ideen- und Geistesgeschichte</langstring>
+      <langstring language="en">Intellectual History</langstring>
+      <langstring language="fr">Histoire intellectuelle</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>909.04924</termIdentifier>
+    <caption>
+      <langstring language="de">Jüdische Geschichte</langstring>
+      <langstring language="en">Jewish History</langstring>
+      <langstring language="fr">Histoire juive</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>200.9</termIdentifier>
+    <caption>
+      <langstring language="de">Kirchen- und Religionsgeschichte</langstring>
+      <langstring language="en">History of religion</langstring>
+      <langstring language="fr">Histoire des religions</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>709</termIdentifier>
+    <caption>
+      <langstring language="de">Kunstgeschichte</langstring>
+      <langstring language="en">Art History</langstring>
+      <langstring language="fr">Histoire de l'art</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>870</termIdentifier>
+    <caption>
+      <langstring language="de">Lateinische Literatur</langstring>
+      <langstring language="en">Latin Literature</langstring>
+      <langstring language="fr">Littérature latine</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>809</termIdentifier>
+    <caption>
+      <langstring language="de">Literaturgeschichte</langstring>
+      <langstring language="en">History of literature</langstring>
+      <langstring language="fr">Histoire littéraire</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>610.9</termIdentifier>
+    <caption>
+      <langstring language="de">Medizingeschichte</langstring>
+      <langstring language="en">History of medicine</langstring>
+      <langstring language="fr">Histoire de la médecine</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>355.009</termIdentifier>
+    <caption>
+      <langstring language="de">Militär- und Kriegsgeschichte</langstring>
+      <langstring language="en">Military History</langstring>
+      <langstring language="fr">Histoire militaire</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>780.9</termIdentifier>
+    <caption>
+      <langstring language="de">Musikgeschichte</langstring>
+      <langstring language="en">Music History</langstring>
+      <langstring language="fr">Histoire de la musique</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>909</termIdentifier>
+    <caption>
+      <langstring language="de">Politikgeschichte</langstring>
+      <langstring language="en">Political History</langstring>
+      <langstring language="fr">Histoire politique</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>340.09</termIdentifier>
+    <caption>
+      <langstring language="de">Rechtsgeschichte</langstring>
+      <langstring language="en">Legal History</langstring>
+      <langstring language="fr">Histoire du droit</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>307.09</termIdentifier>
+    <caption>
+      <langstring language="de">Siedlungs-, Stadt- und Ortsgeschichte</langstring>
+      <langstring language="en">Local History</langstring>
+      <langstring language="fr">Histoire locale</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>306.09</termIdentifier>
+    <caption>
+      <langstring language="de">Sozial- und Kulturgeschichte</langstring>
+      <langstring language="en">Social and Cultural History</langstring>
+      <langstring language="fr">Histoire culturelle et sociale</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>796.09</termIdentifier>
+    <caption>
+      <langstring language="de">Sportgeschichte</langstring>
+      <langstring language="en">History of sport</langstring>
+      <langstring language="fr">Histoire du sport</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>417.7</termIdentifier>
+    <caption>
+      <langstring language="de">Sprachgeschichte</langstring>
+      <langstring language="en">Historical Linguistics</langstring>
+      <langstring language="fr">Linguistique comparée</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>609</termIdentifier>
+    <caption>
+      <langstring language="de">Technikgeschichte</langstring>
+      <langstring language="en">History of technology</langstring>
+      <langstring language="fr">Histoire des techniques</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>792.09</termIdentifier>
+    <caption>
+      <langstring language="de">Theatergeschichte</langstring>
+      <langstring language="en">History of theatre</langstring>
+      <langstring language="fr">Histoire du théâtre</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>901</termIdentifier>
+    <caption>
+      <langstring language="de">Theorie + Methode der Geschichtswissenschaft</langstring>
+      <langstring language="en">Historiography</langstring>
+      <langstring language="fr">Épistémologie et historiographie</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>333709</termIdentifier>
+    <caption>
+      <langstring language="de">Umweltgeschichte</langstring>
+      <langstring language="en">Environmental History</langstring>
+      <langstring language="fr">Histoire environnementale</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>351.09</termIdentifier>
+    <caption>
+      <langstring language="de">Verwaltungsgeschichte</langstring>
+      <langstring language="en">History of administration</langstring>
+      <langstring language="fr">Histoire de l'administration</langstring>
+    </caption>
+  </term>
+
+  <term>
+    <termIdentifier>330.09</termIdentifier>
+    <caption>
+      <langstring language="de">Wirtschaftsgeschichte</langstring>
+      <langstring language="en">Economic History</langstring>
+      <langstring language="fr">Histoire économique</langstring>
+    </caption>
+  </term>
+
+</vdex>

--- a/src/recensio/plone/vocabularies/vdex/ddc_zeit.vdex
+++ b/src/recensio/plone/vocabularies/vdex/ddc_zeit.vdex
@@ -11,7 +11,7 @@
   <vocabName>
     <langstring language="en">International Standard Classification of Occupations, ISCO-88</langstring>
   </vocabName>
-  <vocabIdentifier>ISCO88</vocabIdentifier>
+  <vocabIdentifier>recensio.plone.vocabularies.epoch_values</vocabIdentifier>
   <term>
 <termIdentifier>0901</termIdentifier>
 <caption>

--- a/src/recensio/plone/vocabularies/vdex/ddc_zeit.vdex
+++ b/src/recensio/plone/vocabularies/vdex/ddc_zeit.vdex
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vdex xmlns="http://www.imsglobal.org/xsd/imsvdex_v1p0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.imsglobal.org/xsd/imsvdex_v1p0
+                          imsvdex_v1p0.xsd imsvdex_v1p0_thesaurus.xsd
+                          http://www.imsglobal.org/xsd/imsmd_rootv1p2p1
+                          imsmd_rootv1p2p1.xsd"
+      orderSignificant="true"
+      profileType="flatTokenTerms"
+      language="en">
+  <vocabName>
+    <langstring language="en">International Standard Classification of Occupations, ISCO-88</langstring>
+  </vocabName>
+  <vocabIdentifier>ISCO88</vocabIdentifier>
+  <term>
+<termIdentifier>0901</termIdentifier>
+<caption>
+<langstring language="de">bis 499 n. Chr.</langstring>
+<langstring language="en">until 499 AD</langstring>
+<langstring language="fr">jusqu'à 499 ap. J.-C.</langstring>
+</caption>
+<term>
+<termIdentifier>09012</termIdentifier>
+<caption>
+<langstring language="de">vor 4000 v. Chr.</langstring>
+<langstring language="en">before 4000 BC</langstring>
+<langstring language="fr">avant 4000 av. J.-C.</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09013</termIdentifier>
+<caption>
+<langstring language="de">3999-1000 v. Chr.</langstring>
+<langstring language="en">3999-1000 BC</langstring>
+<langstring language="fr">de 3999 à 1000 av. J.-C.</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09014</termIdentifier>
+<caption>
+<langstring language="de">999 - 1  v. Chr.</langstring>
+<langstring language="en">999 - 1 BC</langstring>
+<langstring language="fr">de 999 à 1 av. J.-C.</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09015</termIdentifier>
+<caption>
+<langstring language="de">1 - 5.  Jh. n. Chr.</langstring>
+<langstring language="en">1st - 5th century AD</langstring>
+<langstring language="fr">Ier - Ve siècle après JC</langstring>
+</caption>
+
+</term>
+</term>
+<term>
+<termIdentifier>0902</termIdentifier>
+<caption>
+<langstring language="de">Mittelalter</langstring>
+<langstring language="en">Middle Ages</langstring>
+<langstring language="fr">Moyen Âge</langstring>
+</caption>
+<term>
+<termIdentifier>09021</termIdentifier>
+<caption>
+<langstring language="de">6. - 12. Jh.</langstring>
+<langstring language="en">6th - 12th century</langstring>
+<langstring language="fr">VIe - XIIe siècle</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09022</termIdentifier>
+<caption>
+<langstring language="de">13. Jh.</langstring>
+<langstring language="en">13th century</langstring>
+<langstring language="fr">XIIIe siècle</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09023</termIdentifier>
+<caption>
+<langstring language="de">14. Jh.</langstring>
+<langstring language="en">14th century</langstring>
+<langstring language="fr">XIVe siècle</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09024</termIdentifier>
+<caption>
+<langstring language="de">15. Jh.</langstring>
+<langstring language="en">15th century</langstring>
+<langstring language="fr">XVe siècle</langstring>
+</caption>
+
+</term>
+</term>
+<term>
+<termIdentifier>0903</termIdentifier>
+<caption>
+<langstring language="de">Neuzeit bis 1900</langstring>
+<langstring language="en">Modern age until 1900</langstring>
+<langstring language="fr">Époque moderne jusqu'à 1900</langstring>
+</caption>
+<term>
+<termIdentifier>09031</termIdentifier>
+<caption>
+<langstring language="de">16. Jh.</langstring>
+<langstring language="en">16th century</langstring>
+<langstring language="fr">XVIe siècle</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09032</termIdentifier>
+<caption>
+<langstring language="de">17. Jh.</langstring>
+<langstring language="en">17th century</langstring>
+<langstring language="fr">XVIIe siècle</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09033</termIdentifier>
+<caption>
+<langstring language="de">18. Jh.</langstring>
+<langstring language="en">18th century</langstring>
+<langstring language="fr">XVIIIe siècle</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09034</termIdentifier>
+<caption>
+<langstring language="de">19. Jh.</langstring>
+<langstring language="en">19th century</langstring>
+<langstring language="fr">XIXe siècle</langstring>
+</caption>
+
+</term>
+</term>
+<term>
+<termIdentifier>0904</termIdentifier>
+<caption>
+<langstring language="de">20. Jahrhundert</langstring>
+<langstring language="en">20th century</langstring>
+<langstring language="fr">XXe siècle</langstring>
+</caption>
+<term>
+<termIdentifier>09041</termIdentifier>
+<caption>
+<langstring language="de">1900 - 1919</langstring>
+<langstring language="en">1900 - 1919</langstring>
+<langstring language="fr">1900 - 1919</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09042</termIdentifier>
+<caption>
+<langstring language="de">1920 - 1929</langstring>
+<langstring language="en">1920 - 1929</langstring>
+<langstring language="fr">1920 - 1929</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09043</termIdentifier>
+<caption>
+<langstring language="de">1930 - 1939</langstring>
+<langstring language="en">1930 - 1939</langstring>
+<langstring language="fr">1930 - 1939</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09044</termIdentifier>
+<caption>
+<langstring language="de">1940 - 1949</langstring>
+<langstring language="en">1940 - 1949</langstring>
+<langstring language="fr">1940 - 1949</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09045</termIdentifier>
+<caption>
+<langstring language="de">1950 - 1959</langstring>
+<langstring language="en">1950 - 1959</langstring>
+<langstring language="fr">1950 - 1959</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09046</termIdentifier>
+<caption>
+<langstring language="de">1960 - 1969</langstring>
+<langstring language="en">1960 - 1969</langstring>
+<langstring language="fr">1960 - 1969</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09047</termIdentifier>
+<caption>
+<langstring language="de">1970 - 1979</langstring>
+<langstring language="en">1970 - 1979</langstring>
+<langstring language="fr">1970 - 1979</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09048</termIdentifier>
+<caption>
+<langstring language="de">1980 - 1989</langstring>
+<langstring language="en">1980 - 1989</langstring>
+<langstring language="fr">1980 - 1989</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>09049</termIdentifier>
+<caption>
+<langstring language="de">1990 - 1999</langstring>
+<langstring language="en">1990 - 1999</langstring>
+<langstring language="fr">1990 - 1999</langstring>
+</caption>
+
+</term>
+</term>
+<term>
+<termIdentifier>0905</termIdentifier>
+<caption>
+<langstring language="de">21. Jahrhundert</langstring>
+<langstring language="en">21st century</langstring>
+<langstring language="fr">XXIe siècle</langstring>
+</caption>
+<term>
+<termIdentifier>090511</termIdentifier>
+<caption>
+<langstring language="de">2000-2009</langstring>
+<langstring language="en">2000-2009</langstring>
+<langstring language="fr">2000-2009</langstring>
+</caption>
+
+</term>
+<term>
+<termIdentifier>090512</termIdentifier>
+<caption>
+<langstring language="de">2010-2019</langstring>
+<langstring language="en">2010-2019</langstring>
+<langstring language="fr">2010-2019</langstring>
+</caption>
+
+</term>
+</term>
+</vdex>


### PR DESCRIPTION
- Add missing Base behavior fields
- integrate collective.vdexvocabularies
- Add vdex vocabularies

Note: There are more vocabs in recensio.altertum, recensio.artium and recensio.regio. But searching for those in the code base it seems like those vdex vocabularies are nowhere used.