### PR TITLE
CT: Add IReview behavior and let review and presentation implement it.

### DIFF
--- a/src/recensio/plone/content/presentation_article_review.py
+++ b/src/recensio/plone/content/presentation_article_review.py
@@ -1,5 +1,6 @@
 from plone.dexterity.content import Item
 from plone.supermodel import model
+from recensio.plone.interfaces import IReview
 from zope.interface import implementer
 
 
@@ -8,6 +9,6 @@ class IPresentationArticleReview(model.Schema):
     PresentationArticleReview."""
 
 
-@implementer(IPresentationArticleReview)
+@implementer(IPresentationArticleReview, IReview)
 class PresentationArticleReview(Item):
     """Content-type class for IPresentationArticleReview."""

--- a/src/recensio/plone/content/presentation_collection.py
+++ b/src/recensio/plone/content/presentation_collection.py
@@ -1,5 +1,6 @@
 from plone.dexterity.content import Item
 from plone.supermodel import model
+from recensio.plone.interfaces import IReview
 from zope.interface import implementer
 
 
@@ -8,6 +9,6 @@ class IPresentationCollection(model.Schema):
     PresentationCollection."""
 
 
-@implementer(IPresentationCollection)
+@implementer(IPresentationCollection, IReview)
 class PresentationCollection(Item):
     """Content-type class for IPresentationCollection."""

--- a/src/recensio/plone/content/presentation_monograph.py
+++ b/src/recensio/plone/content/presentation_monograph.py
@@ -1,5 +1,6 @@
 from plone.dexterity.content import Item
 from plone.supermodel import model
+from recensio.plone.interfaces import IReview
 from zope.interface import implementer
 
 
@@ -8,6 +9,6 @@ class IPresentationMonograph(model.Schema):
     PresentationMonograph."""
 
 
-@implementer(IPresentationMonograph)
+@implementer(IPresentationMonograph, IReview)
 class PresentationMonograph(Item):
     """Content-type class for IPresentationMonograph."""

--- a/src/recensio/plone/content/presentation_online_resource.py
+++ b/src/recensio/plone/content/presentation_online_resource.py
@@ -1,5 +1,6 @@
 from plone.dexterity.content import Item
 from plone.supermodel import model
+from recensio.plone.interfaces import IReview
 from zope.interface import implementer
 
 
@@ -8,6 +9,6 @@ class IPresentationOnlineResource(model.Schema):
     PresentationOnlineResource."""
 
 
-@implementer(IPresentationOnlineResource)
+@implementer(IPresentationOnlineResource, IReview)
 class PresentationOnlineResource(Item):
     """Content-type class for IPresentationOnlineResource."""

--- a/src/recensio/plone/content/review_article_collection.py
+++ b/src/recensio/plone/content/review_article_collection.py
@@ -3,6 +3,7 @@ from plone.dexterity.content import Item
 from plone.supermodel import model
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
+from recensio.plone.interfaces import IReview
 from recensio.plone.utils import get_formatted_names
 from recensio.plone.utils import getFormatter
 from recensio.plone.utils import punctuated_title_and_subtitle
@@ -43,7 +44,7 @@ class IReviewArticleCollection(model.Schema):
 # * field `heading_presented_work` from Printed Review is hidden
 
 
-@implementer(IReviewArticleCollection)
+@implementer(IReviewArticleCollection, IReview)
 class ReviewArticleCollection(Item):
     """Content-type class for IReviewArticleCollection."""
 

--- a/src/recensio/plone/content/review_article_journal.py
+++ b/src/recensio/plone/content/review_article_journal.py
@@ -4,6 +4,7 @@ from plone.supermodel import model
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
 from recensio.plone.behaviors.directives import fieldset_reviewed_text
+from recensio.plone.interfaces import IReview
 from recensio.plone.utils import getFormatter
 from recensio.plone.utils import punctuated_title_and_subtitle
 from zope import schema
@@ -47,7 +48,7 @@ class IReviewArticleJournal(model.Schema):
 # * ReviewArticleJournalSchema["languageReviewedText"].label = _(u"Sprache (Aufsatz)")
 
 
-@implementer(IReviewArticleJournal)
+@implementer(IReviewArticleJournal, IReview)
 class ReviewArticleJournal(Item):
     """Content-type class for IReviewArticleJournal."""
 

--- a/src/recensio/plone/content/review_exhibition.py
+++ b/src/recensio/plone/content/review_exhibition.py
@@ -8,6 +8,7 @@ from plone.supermodel import model
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
 from recensio.plone.behaviors.directives import fieldset_exhibition
+from recensio.plone.interfaces import IReview
 from recensio.plone.utils import get_formatted_names
 from recensio.plone.utils import getFormatter
 from recensio.plone.utils import punctuated_title_and_subtitle
@@ -150,7 +151,7 @@ class IReviewExhibition(model.Schema):
     )
 
 
-@implementer(IReviewExhibition)
+@implementer(IReviewExhibition, IReview)
 class ReviewExhibition(Item):
     """Content-type class for IReviewExhibition."""
 

--- a/src/recensio/plone/content/review_journal.py
+++ b/src/recensio/plone/content/review_journal.py
@@ -4,6 +4,7 @@ from plone.supermodel import model
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
 from recensio.plone.behaviors.directives import fieldset_reviewed_text
+from recensio.plone.interfaces import IReview
 from recensio.plone.utils import getFormatter
 from zope import schema
 from zope.interface import implementer
@@ -33,7 +34,7 @@ class IReviewJournal(model.Schema):
 # * field `subtitle` from Printed Review is hidden
 
 
-@implementer(IReviewJournal)
+@implementer(IReviewJournal, IReview)
 class ReviewJournal(Item):
     """Content-type class for IReviewJournal."""
 

--- a/src/recensio/plone/content/review_monograph.py
+++ b/src/recensio/plone/content/review_monograph.py
@@ -4,6 +4,7 @@ from plone.supermodel import model
 from recensio.plone import _
 from recensio.plone.behaviors.base import IBase
 from recensio.plone.behaviors.directives import fieldset_reviewed_text
+from recensio.plone.interfaces import IReview
 from recensio.plone.utils import getFormatter
 from recensio.plone.utils import punctuated_title_and_subtitle
 from zope import schema
@@ -23,7 +24,7 @@ class IReviewMonograph(model.Schema):
     fieldset_reviewed_text(["translatedTitle"])
 
 
-@implementer(IReviewMonograph)
+@implementer(IReviewMonograph, IReview)
 class ReviewMonograph(Item):
     """Content-type class for IReviewMonograph."""
 

--- a/src/recensio/plone/interfaces.py
+++ b/src/recensio/plone/interfaces.py
@@ -1,5 +1,10 @@
+from zope.interface import Interface
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 
 
 class IRecensioPloneLayer(IDefaultBrowserLayer):
     """Marker interface that defines a browser layer."""
+
+
+class IReview(Interface):
+    """Marker interface for reviews and other select content types."""


### PR DESCRIPTION
I did it by letting the content type classes implement `IReview` instead of adding a marker interface.

I'm still a bit undecided if that or adding as a marker interface on behaviors is better in terms of readability. the result should be the same.
When adding it as marker interface on behaviors i'd add it to the `base_review` behavior and create another marker interface `IPresentation`, let that derive from `IReview` and add the `IPresentation` interface to `base_presentation`.
