### PR TITLE
Use the portlets to display the right column

### DIFF
--- a/src/recensio/plone/browser/templates/review.pt
+++ b/src/recensio/plone/browser/templates/review.pt
@@ -91,68 +91,7 @@
       ></iframe>
 
     </div>
-    <div tal:define="
-           pdf python:view.get_review_pdf();
-         ">
-      <div class="portlet"
-           id="portletDownload"
-           tal:define="
-             pdf_ob python:pdf and pdf['blob'];
-           "
-           tal:condition="pdf"
-      >
-        <p class="download pdf"
-           tal:condition="not:context/isUseExternalFulltext|nothing"
-        >
-          <a href="PartB.pdf"
-             target="_blank"
-             tal:attributes="
-               href python:context.absolute_url()+'/@@generate-pdf-recension?language='+context.portal_languages.getPreferredLanguage();
-             "
-             i18n:translate="download_as"
-          >Download as
-            <strong>PDF</strong><br />
-            <em class="discrete">(<span tal:replace="python: pdf_ob and pdf['size']/1024 or 0"
-                    i18n:name="download_size"
-              ></span>
-              kb)</em></a>
-        </p>
-        <p class="external fulltext pdf"
-           tal:condition="context/isUseExternalFulltext|nothing"
-        >
-          <a href="${python: view.get_doi_url_if_active() or context.canonical_uri}"
-             target="_blank"
-             i18n:translate=""
-          >
-            Zum Volltext</a>
-        </p>
-      </div>
-
-      <div id="social-media-content">
-        <img id="social-media-buttons-content"
-             alt="Social Media Buttons"
-             src="${context/absolute_url}/++resource++recensio.theme.images/social-media-icons.png"
-             usemap="#socialmap-content"
-        />
-        <map name="socialmap-content">
-          <area alt="fb"
-                coords="0,0,30,30"
-                href="https://www.facebook.com/sharer/sharer.php?u=${context/absolute_url}"
-                shape="rect"
-          />
-          <area alt="twitter"
-                coords="30,0,60,30"
-                href="http://twitter.com/home?status=${context/absolute_url}"
-                shape="rect"
-          />
-          <area alt="twitter"
-                coords="60,0,90,30"
-                href="string:https://www.linkedin.com/shareArticle?mini=true&amp;url=${context/absolute_url}"
-                shape="rect"
-          />
-        </map>
-      </div>
-
+    <div>
       <div tal:define="
              metadata_field_names view/metadata_fields;
              metadata view/get_metadata;

--- a/src/recensio/plone/configure.zcml
+++ b/src/recensio/plone/configure.zcml
@@ -37,6 +37,7 @@
   <include package=".content" />
   <include package=".controlpanel" />
   <include package=".mails" />
+  <include package=".portlets" />
   <include package=".subscribers" />
   <include package=".upgrades" />
   <include package=".vocabularies" />

--- a/src/recensio/plone/portlets/configure.zcml
+++ b/src/recensio/plone/portlets/configure.zcml
@@ -1,0 +1,23 @@
+<!-- Add a Plone portlet that displays some text -->
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    >
+
+  <plone:portlet
+      name="recensio.plone.portlets.get_pdf"
+      interface=".get_pdf.IGetPDFPortlet"
+      assignment=".get_pdf.Assignment"
+      renderer=".get_pdf.Renderer"
+      addview=".get_pdf.AddForm"
+      />
+
+  <plone:portlet
+      name="recensio.plone.portlets.social_links"
+      interface=".social_links.ISocialLinksPortlet"
+      assignment=".social_links.Assignment"
+      renderer=".social_links.Renderer"
+      addview=".social_links.AddForm"
+      />
+
+</configure>

--- a/src/recensio/plone/portlets/get_pdf.py
+++ b/src/recensio/plone/portlets/get_pdf.py
@@ -1,0 +1,29 @@
+from plone.app.portlets.portlets import base
+from plone.portlets.interfaces import IPortletDataProvider
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from recensio.plone import _
+from recensio.plone.interfaces import IReview
+from zope.interface import implementer
+
+
+class IGetPDFPortlet(IPortletDataProvider):
+    """A portlet to get a pdf from a review."""
+
+
+@implementer(IGetPDFPortlet)
+class Assignment(base.Assignment):
+
+    title = _("label_log_in", default="Recensio PDF Portlet")
+
+
+class Renderer(base.Renderer):
+    render = ViewPageTemplateFile("templates/get_pdf.pt")
+
+    @property
+    def available(self):
+        return IReview.providedBy(self.context)
+
+
+class AddForm(base.NullAddForm):
+    def create(self):
+        return Assignment()

--- a/src/recensio/plone/portlets/social_links.py
+++ b/src/recensio/plone/portlets/social_links.py
@@ -1,0 +1,29 @@
+from plone.app.portlets.portlets import base
+from plone.portlets.interfaces import IPortletDataProvider
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from recensio.plone import _
+from recensio.plone.interfaces import IReview
+from zope.interface import implementer
+
+
+class ISocialLinksPortlet(IPortletDataProvider):
+    """A portlet to display some social links."""
+
+
+@implementer(ISocialLinksPortlet)
+class Assignment(base.Assignment):
+
+    title = _("label_log_in", default="Recensio Social Links Portlet")
+
+
+class Renderer(base.Renderer):
+    render = ViewPageTemplateFile("templates/social_links.pt")
+
+    @property
+    def available(self):
+        return IReview.providedBy(self.context)
+
+
+class AddForm(base.NullAddForm):
+    def create(self):
+        return Assignment()

--- a/src/recensio/plone/portlets/templates/get_pdf.pt
+++ b/src/recensio/plone/portlets/templates/get_pdf.pt
@@ -1,0 +1,38 @@
+<div tal:define="
+       review_view nocall:here/@@review_view;
+       pdf python:review_view.get_review_pdf();
+     ">
+  <div class="portlet"
+       id="portletDownload"
+       tal:define="
+         pdf_ob python:pdf and pdf['blob'];
+       "
+       tal:condition="pdf"
+  >
+    <p class="download pdf"
+       tal:condition="not:context/isUseExternalFulltext|nothing"
+    >
+      <a href="PartB.pdf"
+         target="_blank"
+         tal:attributes="
+           href python:context.absolute_url()+'/@@generate-pdf-recension?language='+context.portal_languages.getPreferredLanguage();
+         "
+         i18n:translate="download_as"
+      >Download as
+        <strong>PDF</strong><br />
+        <em class="discrete">(<span tal:replace="python: pdf_ob and pdf['size']/1024 or 0"
+                i18n:name="download_size"
+          ></span>
+          kb)</em></a>
+    </p>
+    <p class="external fulltext pdf"
+       tal:condition="context/isUseExternalFulltext|nothing"
+    >
+      <a href="${python: review_view.get_doi_url_if_active() or context.canonical_uri}"
+         target="_blank"
+         i18n:translate=""
+      >
+        Zum Volltext</a>
+    </p>
+  </div>
+</div>

--- a/src/recensio/plone/portlets/templates/social_links.pt
+++ b/src/recensio/plone/portlets/templates/social_links.pt
@@ -1,0 +1,25 @@
+
+<div id="social-media-content">
+  <img id="social-media-buttons-content"
+       alt="Social Media Buttons"
+       src="${context/absolute_url}/++resource++recensio.theme.images/social-media-icons.png"
+       usemap="#socialmap-content"
+  />
+  <map name="socialmap-content">
+    <area alt="fb"
+          coords="0,0,30,30"
+          href="https://www.facebook.com/sharer/sharer.php?u=${context/absolute_url}"
+          shape="rect"
+    />
+    <area alt="twitter"
+          coords="30,0,60,30"
+          href="http://twitter.com/home?status=${context/absolute_url}"
+          shape="rect"
+    />
+    <area alt="twitter"
+          coords="60,0,90,30"
+          href="string:https://www.linkedin.com/shareArticle?mini=true&amp;url=${context/absolute_url}"
+          shape="rect"
+    />
+  </map>
+</div>

--- a/src/recensio/plone/profiles/default/portlets.xml
+++ b/src/recensio/plone/profiles/default/portlets.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<portlets xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+          i18n:domain="plone"
+>
+
+  <portlet addview="recensio.plone.portlets.get_pdf.AddForm"
+           title="Recensio Get PDF portlet"
+           i18n:attributes="title"
+  />
+
+  <portlet addview="recensio.plone.portlets.social_links.AddForm"
+           title="Recensio Social Links Portlet"
+           i18n:attributes="title"
+  />
+
+  <assignment category="context"
+              for="recensio.plone.interfaces.IReview"
+              manager="plone.rightcolumn"
+              name="recensio.plone.portlets.get_pdf"
+              title="Recensio Get PDF portlet"
+              type="recensio.plone.portlets.get_pdf"
+              i18n:attributes="title"
+  />
+
+  <assignment category="context"
+              for="recensio.plone.interfaces.IReview"
+              manager="plone.rightcolumn"
+              name="recensio.plone.portlets.social_links"
+              title="Recensio Social Links Portlet"
+              type="recensio.plone.portlets.social_links"
+              i18n:attributes="title"
+  />
+
+</portlets>


### PR DESCRIPTION
Remove the code from the review_view and display it on the right portlet column.
I think this will be a nice way to present also the metadata column in a much better way