### PR TITLE
review view: Use form widgets to display content values where applicable.

### DIFF
--- a/src/recensio/plone/browser/templates/review.pt
+++ b/src/recensio/plone/browser/templates/review.pt
@@ -15,6 +15,7 @@
   <div metal:fill-slot="content-core">
     <div class="row">
       <div class="col-8">
+
         <div id="review"
              tal:define="
                searchresults context/getSearchresults | nothing;
@@ -159,6 +160,7 @@
         <div tal:define="
                metadata_field_names view/metadata_fields;
                metadata view/get_metadata;
+               widgets view/widgets;
              ">
           <span class="Z3988"
                 title="${view/get_metadata_context_object}"
@@ -185,19 +187,26 @@
                   <div class="card-body accordion-content">
                     <dl>
                       <tal:field_names repeat="field_name metadata_field_names">
-                        <tal:has_value condition="python:metadata[field_name]['value']">
-                          <dt tal:content="python:metadata[field_name]['label']">
-                            Editor (name or institution)
+                        <tal:def define="
+                                   data python:metadata[field_name];
+                                   use_widget_view data/use_widget_view;
+                                   widget python:widgets.get(field_name);
+                                 "
+                                 condition="data/value"
+                        >
+                          <dt>
+                              ${data/label}
                           </dt>
-                          <dd tal:condition="python: metadata[field_name]['is_macro']">
-                            <metal:val use-macro="python: context.widget(field_name, mode='view')" />
-                          </dd>
-                          <dd tal:condition="python: not metadata[field_name]['is_macro']"
-                              tal:content="structure python: metadata[field_name]['value']"
-                          >
-                            Frank Severin
-                          </dd>
-                        </tal:has_value>
+
+                          <tal:widget switch="python:bool(use_widget_view and widget)">
+                            <dd tal:case="True">
+                              <tal:rep replace="structure widget/render" />
+                            </dd>
+                            <dd tal:case="default">
+                              <tal:rep replace="structure data/value" />
+                            </dd>
+                          </tal:widget>
+                        </tal:def>
                       </tal:field_names>
                     </dl>
                   </div>


### PR DESCRIPTION
Note: I took a different approach than to subclass `plone.dexterity.browser.view.DefaultView` for these reasons:

- The DefaultView/plone.autoform are respecting the OMIT directives and won't include all the widgets.
- DefaultView groups all widgets in a main and fieldset schemata. I need it here flat.
- DefaultView does a lot of other magic not needed here.
- Our review view isn't polluted with methods and attributes from the DefaultView.

Now the review view renders like this:

![image](https://user-images.githubusercontent.com/170891/216030794-4190c8e4-f852-49ac-9dcb-d9ba4d9f1e2c.png)

