### PR TITLE
Revert "Makefile: use py instead py3 as subdirectory."

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,35 +2,36 @@
 all: .installed.cfg
 
 
-py/bin/buildout: py/bin/pip3 py/bin/pre-commit
-	./py/bin/pip3 uninstall -y setuptools
-	./py/bin/pip3 install -IUr https://dist.plone.org/release/6-latest/requirements.txt
+py3/bin/buildout: py3/bin/pip3 py3/bin/pre-commit
+	./py3/bin/pip3 uninstall -y setuptools
+	./py3/bin/pip3 install -IUr https://dist.plone.org/release/6-latest/requirements.txt
 
 
-pre-commit: py/bin/pre-commit
-py/bin/pre-commit: py/bin/pip3
-	./py/bin/pip3 install pre-commit
-	./py/bin/pre-commit install
+.PHONY: pre-commit
+pre-commit: py3/bin/pre-commit
+py3/bin/pre-commit: py3/bin/pip3
+	./py3/bin/pip3 install pre-commit
+	./py3/bin/pre-commit install
 
 
-py/bin/pip3:
-	python3 -m venv py
+py3/bin/pip3:
+	python3 -m venv py3
 
 
-.installed.cfg: py/bin/buildout
-	./py/bin/buildout
+.installed.cfg: py3/bin/buildout
+	./py3/bin/buildout
 
 
 .PHONY: check
 check: .installed.cfg
-	./py/bin/pre-commit run --all-files
+	./py3/bin/pre-commit run --all-files
 	./bin/coverage run ./bin/test -s recensio.plone
 	./bin/coverage report --fail-under=10 -i
 
 
 .PHONY: clean
 clean:
-	rm -rf ./py
+	rm -rf ./py3
 
 
 # Build custom JavaScript bundle


### PR DESCRIPTION
This reverts commit 1d561bcdf95c3d0ca93ab22b8243016df1998bbb.

Revert a stupid rename.