### PR TITLE
Omit the id field from the view page of content types

### DIFF
--- a/src/recensio/plone/content/__init__.py
+++ b/src/recensio/plone/content/__init__.py
@@ -1,0 +1,15 @@
+from plone.app.dexterity.behaviors.id import IShortName
+from plone.autoform.interfaces import OMITTED_KEY
+from z3c.form.interfaces import IAddForm
+from z3c.form.interfaces import IEditForm
+from zope.interface import Interface
+
+
+IShortName.setTaggedValue(
+    OMITTED_KEY,
+    [
+        (Interface, "id", "true"),
+        (IAddForm, "id", "false"),
+        (IEditForm, "id", "false"),
+    ],
+)


### PR DESCRIPTION
This prevents the `id` field to be displayed in the views of the content types that use the `plone.shortname` behavior, e.g. the `Person` content type