### PR TITLE
scrum-1191 - missing subjects in metadata column.

### DIFF
--- a/src/recensio/plone/browser/review.py
+++ b/src/recensio/plone/browser/review.py
@@ -307,6 +307,11 @@ class View(BrowserView, CanonicalURLHelper):
                         context=context, request=self.request, name="plone"
                     )
                     value = ploneview.toLocalizedTime(effective_date, long_format=False)
+            elif field == "subjects":
+                label = self.get_label(field)
+                # NOTE: the behavior field is `subjects` but it's stored as
+                #       `subject` on the context.
+                value = "<br/>".join(getattr(context, "subject", []))
             else:
                 if field == "ddcSubject":
                     label = _("Subject classification")
@@ -318,7 +323,7 @@ class View(BrowserView, CanonicalURLHelper):
                     label = self.get_label(field)
                 # The macro is used in the template, the value is
                 # used to determine whether to display that row or not
-                value = getattr(context, field) and True or False
+                value = True if getattr(context, field) else False
                 use_widget_view = True
             meta[field] = {
                 "label": label,


### PR DESCRIPTION
Ref: scrum-1191


Side note: I started also another approach by trying to customize the textlines display widget:
https://github.com/syslabcom/recensio.plone/tree/scrum-1191--custom-widget
The default textlines display widget isn't very useful because it displays the textlines in one line without any visible separator.
Customizing the textlines display widget would have allowed for a bit more complex display of textlines (using ul/li) than just adding a line break.
However, that didn't work.
Improving the z3c form stack for Plone would be a topic for a future community sprint.
