### PR TITLE
scrum-1195: Set menu structure.

### DIFF
--- a/src/recensio/plone/profiles/default/actions.xml
+++ b/src/recensio/plone/profiles/default/actions.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Plone Actions Tool"
+        name="portal_actions"
+>
+  <object meta_type="CMF Action Category"
+          name="portal_tabs"
+  >
+    <property name="title">Portal tabs</property>
+    <object meta_type="CMF Action"
+            name="rezensionen"
+            i18n:domain="recensio"
+    >
+      <property name="title"
+                i18n:translate=""
+      >label_nav_reviews</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">string:${portal/rezensionen/absolute_url}/rezensionen</property>
+      <property name="link_target" />
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions" />
+      <property name="visible">True</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="journals"
+            i18n:domain="recensio"
+    >
+      <property name="title"
+                i18n:translate=""
+      >label_nav_journals</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">portal/rezensionen/zeitschriften/absolute_url</property>
+      <property name="link_target" />
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions" />
+      <property name="visible">True</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="themes"
+            i18n:domain="recensio"
+    >
+      <property name="title"
+                i18n:translate=""
+      >label_nav_themes</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">string:themen-epochen-regionen</property>
+      <property name="link_target" />
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions" />
+      <property name="visible">True</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="authors"
+            i18n:domain="recensio"
+    >
+      <property name="title"
+                i18n:translate=""
+      >label_nav_authors</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">string:${portal_url}/@@authorsearch</property>
+      <property name="link_target" />
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions" />
+      <property name="visible">True</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="search"
+            i18n:domain="recensio"
+    >
+      <property name="title"
+                i18n:translate=""
+      >label_nav_search</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">string:${portal_url}/@@search</property>
+      <property name="link_target" />
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions" />
+      <property name="visible">True</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="aboutus"
+            i18n:domain="recensio"
+    >
+      <property name="title"
+                i18n:translate=""
+      >label_nav_about_us</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">string:${portal_url}/ueber-uns</property>
+      <property name="link_target" />
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions" />
+      <property name="visible">True</property>
+    </object>
+  </object>
+</object>

--- a/src/recensio/plone/upgrades/v1/20230510221727_set_menu_structure/actions.xml
+++ b/src/recensio/plone/upgrades/v1/20230510221727_set_menu_structure/actions.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Plone Actions Tool"
+        name="portal_actions"
+>
+  <object meta_type="CMF Action Category"
+          name="portal_tabs"
+  >
+    <property name="title">Portal tabs</property>
+    <object meta_type="CMF Action"
+            name="rezensionen"
+            i18n:domain="recensio"
+    >
+      <property name="title"
+                i18n:translate=""
+      >label_nav_reviews</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">string:${portal/rezensionen/absolute_url}/rezensionen</property>
+      <property name="link_target" />
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions" />
+      <property name="visible">True</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="journals"
+            i18n:domain="recensio"
+    >
+      <property name="title"
+                i18n:translate=""
+      >label_nav_journals</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">portal/rezensionen/zeitschriften/absolute_url</property>
+      <property name="link_target" />
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions" />
+      <property name="visible">True</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="themes"
+            i18n:domain="recensio"
+    >
+      <property name="title"
+                i18n:translate=""
+      >label_nav_themes</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">string:themen-epochen-regionen</property>
+      <property name="link_target" />
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions" />
+      <property name="visible">True</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="authors"
+            i18n:domain="recensio"
+    >
+      <property name="title"
+                i18n:translate=""
+      >label_nav_authors</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">string:${portal_url}/@@authorsearch</property>
+      <property name="link_target" />
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions" />
+      <property name="visible">True</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="search"
+            i18n:domain="recensio"
+    >
+      <property name="title"
+                i18n:translate=""
+      >label_nav_search</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">string:${portal_url}/@@search</property>
+      <property name="link_target" />
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions" />
+      <property name="visible">True</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="aboutus"
+            i18n:domain="recensio"
+    >
+      <property name="title"
+                i18n:translate=""
+      >label_nav_about_us</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">string:${portal_url}/ueber-uns</property>
+      <property name="link_target" />
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions" />
+      <property name="visible">True</property>
+    </object>
+  </object>
+</object>

--- a/src/recensio/plone/upgrades/v1/20230510221727_set_menu_structure/upgrade.py
+++ b/src/recensio/plone/upgrades/v1/20230510221727_set_menu_structure/upgrade.py
@@ -1,0 +1,46 @@
+from ftw.upgrade import UpgradeStep
+from plone import api
+
+
+class SetMenuStructure(UpgradeStep):
+    """Set menu structure."""
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        # Set the "rezensionen" folder to use the "latest-review-items" layout
+        # for all languages
+        portal = api.portal.get()
+        reviews = portal.rezensionen
+
+        reviews_de = api.content.create(
+            container=reviews,
+            type="Document",
+            id="rezensionen",
+            title="Rezensionen",
+            language="de",
+        )
+        reviews_de.setLayout("latest-review-items")
+        api.content.transition(reviews_de, "publish")
+
+        reviews_fr = api.content.create(
+            container=reviews,
+            type="Document",
+            id="recensions",
+            title="Recensions",
+            language="fr",
+        )
+        reviews_fr.setLayout("latest-review-items")
+        api.content.transition(reviews_fr, "publish")
+
+        reviews_en = api.content.create(
+            container=reviews,
+            type="Document",
+            id="reviews",
+            title="Reviews",
+            language="en",
+        )
+        reviews_en.setLayout("latest-review-items")
+        api.content.transition(reviews_en, "publish")
+
+        reviews.setDefaultPage("rezensionen")


### PR DESCRIPTION
This commit sets the recensio portal tabs menu explicitly via actions.xml which was apparently set manually before.
Also, it adds these Documents:
/rezensionen/rezensionen (for German)
/rezensionen/reviews (for English)
/rezensionen/recensions‌ (for French)

to reflect the old URL structure on https://www.recensio.net/

All of those Documents are set to have the layout "latest-review-items"

This solves scrum-1195.

However, I'm not 100% sold on this.

Some problems I see:

- Having content items just to reflect the old URL structure without any other purpose feels odd.
- This is not using any translation machinery, so switching from `fr` to `de` wouldn't switch from `/rezensionen/recensions‌` to `/rezensionen/rezensionen`.

I'm not sure if there is a better solution. I'm open to suggestions.