### PR TITLE
Fix pdf generation

### DIFF
--- a/src/recensio/plone/subscribers/review.py
+++ b/src/recensio/plone/subscribers/review.py
@@ -23,7 +23,8 @@ logger = getLogger(__name__)
 HTML_TEMPLATE = Template(
     """
 <?xml version="1.0"?>
-<html>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
 <body>$body</body>
 </html>
 """.strip()

--- a/src/recensio/plone/subscribers/review.py
+++ b/src/recensio/plone/subscribers/review.py
@@ -22,7 +22,7 @@ logger = getLogger(__name__)
 
 HTML_TEMPLATE = Template(
     """
-<!DOCTYPE html>
+<?xml version="1.0"?>
 <html>
 <body>$body</body>
 </html>

--- a/src/recensio/plone/subscribers/review.py
+++ b/src/recensio/plone/subscribers/review.py
@@ -22,9 +22,9 @@ logger = getLogger(__name__)
 
 HTML_TEMPLATE = Template(
     """
-<?xml version="1.0"?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html>
+<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>
 <body>$body</body>
 </html>
 """.strip()


### PR DESCRIPTION
Adjust the HTML template for generating PDFs to keep both `abiword` and `tidy` happy enough to handle accented characters.

