### PR TITLE
Recensio migration fixes + more

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,4 +37,17 @@ The blob home environment variable must be set to import the page pictures.
 
 Order of import:
 
-1) Users / Members
+ 1) Create fresh Plone instance "recensio"
+ 2) Apply profile `recensio.plone:default`
+
+ 3) Import users (< 5m):           http://localhost:8080/recensio/@@import_members
+ 4) Import content: (3.5-4h):      http://localhost:8080/recensio/@@import_content
+ 5) Import relations: (5 minutes): http://localhost:8080/recensio/@@import_relations
+ 6) Import translations (0):       http://localhost:8080/recensio/@@import_translations
+ 7) Import local roles (< 5m):     http://localhost:8080/recensio/@@import_localroles
+ 8) Import default pages (< 5m):   http://localhost:8080/recensio/@@import_defaultpages
+ 9) Import ordering (~ 20m):       http://localhost:8080/recensio/@@import_ordering
+10) Import portlets (< 5m):        http://localhost:8080/recensio/@@import_portlets
+11) Reset dates (< 5m):            http://localhost:8080/recensio/@@reset_dates
+12) Fix collections (0m):          http://localhost:8080/recensio/@@fix_collection_queries
+13) Fix html (< 5m):               http://localhost:8080/recensio/@@fix_html

--- a/README.rst
+++ b/README.rst
@@ -16,3 +16,20 @@ We need some system packages to be available for this package to be fully functi
 - pdftk (works on pdf)
 - poppler_utils (pdf)
 - html-tidy (cleans up the html that will be converted to pdf)
+
+
+Migration
+=========
+
+Read `Notes on speed and large migrations <https://github.com/collective/collective.exportimport#notes-on-speed-and-large-migrations>`_ in the collective.exportimport README.
+
+Then decide if you want to do an export from Plone 4 and only set blob paths.
+If so, set the `COLLECTIVE_EXPORTIMPORT_BLOB_HOME` variable on import.
+
+Also disable the recensio event subscribers which would generate PDFs from already generated content.
+To do this, set `RECENSIO_DISABLE_SUBSCRIBERS=true`.
+
+After successful migration import the page pictures, which were not in the Recensio Archetypes schema in Plone 4 and therefore not exported.
+The blob home environment variable must be set to import the page pictures.
+
+`http://localhost:8080/recensio/@@import-page-pictures`

--- a/README.rst
+++ b/README.rst
@@ -33,3 +33,8 @@ After successful migration import the page pictures, which were not in the Recen
 The blob home environment variable must be set to import the page pictures.
 
 `http://localhost:8080/recensio/@@import-page-pictures`
+
+
+Order of import:
+
+1) Users / Members

--- a/src/recensio/plone/behaviors/base.py
+++ b/src/recensio/plone/behaviors/base.py
@@ -55,7 +55,7 @@ class IBase(model.Schema):
     languageReview = schema.List(
         title=_("Language(s) (review)"),
         value_type=schema.Choice(
-            vocabulary="plone.app.vocabularies.SupportedContentLanguages"
+            vocabulary="recensio.plone.vocabularies.available_content_languages"
         ),
         required=False,
         defaultFactory=list,
@@ -65,7 +65,7 @@ class IBase(model.Schema):
     languageReviewedText = schema.List(
         title=_("Language(s) (text)"),
         value_type=schema.Choice(
-            vocabulary="plone.app.vocabularies.SupportedContentLanguages"
+            vocabulary="recensio.plone.vocabularies.available_content_languages"
         ),
         required=False,
         defaultFactory=list,

--- a/src/recensio/plone/browser/helper.py
+++ b/src/recensio/plone/browser/helper.py
@@ -63,8 +63,10 @@ class CrossPlatformMixin:
         external_url = None
         with SwitchPortal(other_portal):
             registry = getUtility(IRegistry)
-            recensio_settings = registry.forInterface(IRecensioSettings)
-            external_url = recensio_settings.external_portal_url
+            settings = registry.forInterface(
+                IRecensioSettings, prefix="recensio.plone.settings"
+            )
+            external_url = settings.external_portal_url
         return external_url
 
     def get_foreign_url(self, result):

--- a/src/recensio/plone/browser/pdfgen.py
+++ b/src/recensio/plone/browser/pdfgen.py
@@ -174,8 +174,7 @@ class GeneratePdfRecension(BrowserView):
             error_code = None
             new_path = None
             if pdf:
-                pdf_blob = pdf["blob"]
-                original = pdf_blob.open().name
+                original = pdf.filename
                 fd, new_path = tempfile.mkstemp(prefix="final", suffix=".pdf")
                 os.close(fd)  # 2463
                 # nosec: bandit complains about the use of os.system (B605)

--- a/src/recensio/plone/browser/review.py
+++ b/src/recensio/plone/browser/review.py
@@ -457,12 +457,12 @@ class View(BrowserView, CanonicalURLHelper):
         review_pdf = None
 
         uploaded_pdf = getattr(self.context, "pdf", None)
-        if uploaded_pdf and uploaded_pdf.getSize() > 0:
+        if uploaded_pdf and uploaded_pdf.size > 0:
             review_pdf = uploaded_pdf
 
         if not review_pdf:
             generated_pdf = getattr(self.context, "generatedPdf", None)
-            if generated_pdf.getSize() > 0:
+            if generated_pdf and generated_pdf.size > 0:
                 review_pdf = generated_pdf
 
         return review_pdf

--- a/src/recensio/plone/browser/review.py
+++ b/src/recensio/plone/browser/review.py
@@ -454,27 +454,18 @@ class View(BrowserView, CanonicalURLHelper):
         Also return the size since it is not easy to get this from the
         blob directly
         """
-        pdf = {}
-        size = 0
-        pdf_attribute = getattr(self.context, "pdf", None)
+        review_pdf = None
 
-        if pdf_attribute:
-            size = pdf_attribute.getSize()
-            if size > 0:
-                pdf["size"] = size
-                pdf["blob"] = pdf_attribute._blob
+        uploaded_pdf = getattr(self.context, "pdf", None)
+        if uploaded_pdf and uploaded_pdf.getSize() > 0:
+            review_pdf = uploaded_pdf
 
-        generated_pdf = getattr(self.context, "generatedPdf", None)
-        if size == 0 and generated_pdf:
-            size = generated_pdf.getSize()
-            if size > 0:
-                pdf["size"] = size
-                pdf["blob"] = generated_pdf._blob
+        if not review_pdf:
+            generated_pdf = getattr(self.context, "generatedPdf", None)
+            if generated_pdf.getSize() > 0:
+                review_pdf = generated_pdf
 
-        if pdf == {}:
-            return None
-        else:
-            return pdf
+        return review_pdf
 
     def getLicense(self):
         # XXX It might need some tweaks if we port the presentations

--- a/src/recensio/plone/browser/templates/review.pt
+++ b/src/recensio/plone/browser/templates/review.pt
@@ -122,7 +122,7 @@
                i18n:translate="download_as"
             >Download as
               <strong>PDF</strong><br />
-              <em class="discrete">(<span tal:replace="python: pdf_size/1024 if pdf_size else 0"
+              <em class="discrete">(<span tal:replace="python: round(pdf_size/1024) if pdf_size else 0"
                       i18n:name="download_size"
                 ></span>
                 kb)</em></a>

--- a/src/recensio/plone/browser/templates/review.pt
+++ b/src/recensio/plone/browser/templates/review.pt
@@ -107,13 +107,11 @@
       <div class="col-md-4"
            tal:define="
              pdf python:view.get_review_pdf();
+             pdf_size python:pdf and pdf.getSize();
            "
       >
         <div class="card portlet"
              id="portletDownload"
-             tal:define="
-               pdf_ob python:pdf and pdf['blob'];
-             "
              tal:condition="pdf"
         >
           <div class="card-body download pdf"
@@ -124,7 +122,7 @@
                i18n:translate="download_as"
             >Download as
               <strong>PDF</strong><br />
-              <em class="discrete">(<span tal:replace="python: pdf_ob and pdf['size']/1024 or 0"
+              <em class="discrete">(<span tal:replace="python: pdf_size/1024 if pdf_size else 0"
                       i18n:name="download_size"
                 ></span>
                 kb)</em></a>

--- a/src/recensio/plone/migration/configure.zcml
+++ b/src/recensio/plone/migration/configure.zcml
@@ -1,6 +1,8 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    zcml:condition="installed collective.exportimport"
     >
 
   <browser:page

--- a/src/recensio/plone/migration/configure.zcml
+++ b/src/recensio/plone/migration/configure.zcml
@@ -11,4 +11,16 @@
       layer="recensio.plone.interfaces.IRecensioPloneLayer"
       />
 
+  <configure package="collective.exportimport">
+    <browser:page
+        name="import_relations"
+        for="zope.interface.Interface"
+        class="recensio.plone.migration.import_relations.ImportRelations"
+        template="templates/import_relations.pt"
+        permission="cmf.ManagePortal"
+        layer="recensio.plone.interfaces.IRecensioPloneLayer"
+        />
+  </configure>
+
+
 </configure>

--- a/src/recensio/plone/migration/import_relations.py
+++ b/src/recensio/plone/migration/import_relations.py
@@ -1,4 +1,13 @@
-from collective.exportimport.import_other import ImportRelations as OrigImportRelations
+try:
+    from collective.exportimport.import_other import (
+        ImportRelations as OrigImportRelations,
+    )
+except ImportError:
+    # Just a dummy import to not break this module when c.exportimport is not
+    # installed.
+    from Products.Five.browser import BrowserView
+
+    OrigImportRelations = BrowserView
 
 
 class ImportRelations(OrigImportRelations):

--- a/src/recensio/plone/migration/import_relations.py
+++ b/src/recensio/plone/migration/import_relations.py
@@ -1,0 +1,16 @@
+from collective.exportimport.import_other import ImportRelations as OrigImportRelations
+
+
+class ImportRelations(OrigImportRelations):
+    # Define relationship to field mapping for Recensio.
+    RELATIONSHIP_FIELD_MAPPING = {
+        # default relations of Plone 4 > 5
+        "Working Copy Relation": "iterate-working-copy",
+        "relatesTo": "relatedItems",
+        # recensio specific relations
+        "author": "authors",
+        "reviewAuthor": "reviewAuthors",
+        "editor": "editorial",
+        "custom_licence": "licence_ref",
+        "curator": "curators",
+    }

--- a/src/recensio/plone/profiles/default/registry/language.xml
+++ b/src/recensio/plone/profiles/default/registry/language.xml
@@ -24,41 +24,5 @@
     <value key="use_subdomain_negotiation">False</value>
   </records>
 
-  <record name="recensio.plone.settings.available_content_languages">
-    <value>sq&#13;
-hy&#13;
-az&#13;
-bs&#13;
-bg&#13;
-ca&#13;
-hr&#13;
-cs&#13;
-da&#13;
-nl&#13;
-en&#13;
-et&#13;
-fi&#13;
-fr&#13;
-ka&#13;
-de&#13;
-el&#13;
-hu&#13;
-it&#13;
-la&#13;
-lv&#13;
-lt&#13;
-no&#13;
-pl&#13;
-pt&#13;
-ro&#13;
-ru&#13;
-sr&#13;
-sk&#13;
-sl&#13;
-es&#13;
-sv&#13;
-tr&#13;
-uk</value>
-  </record>
 
 </registry>

--- a/src/recensio/plone/profiles/default/registry/language.xml
+++ b/src/recensio/plone/profiles/default/registry/language.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<registry>
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+          i18n:domain="recensio"
+>
   <records interface="plone.i18n.interfaces.ILanguageSchema"
            prefix="plone"
   >
@@ -21,4 +23,42 @@
     <value key="use_request_negotiation">False</value>
     <value key="use_subdomain_negotiation">False</value>
   </records>
+
+  <record name="recensio.plone.settings.available_content_languages">
+    <value>sq&#13;
+hy&#13;
+az&#13;
+bs&#13;
+bg&#13;
+ca&#13;
+hr&#13;
+cs&#13;
+da&#13;
+nl&#13;
+en&#13;
+et&#13;
+fi&#13;
+fr&#13;
+ka&#13;
+de&#13;
+el&#13;
+hu&#13;
+it&#13;
+la&#13;
+lv&#13;
+lt&#13;
+no&#13;
+pl&#13;
+pt&#13;
+ro&#13;
+ru&#13;
+sr&#13;
+sk&#13;
+sl&#13;
+es&#13;
+sv&#13;
+tr&#13;
+uk</value>
+  </record>
+
 </registry>

--- a/src/recensio/plone/profiles/default/registry/settings.xml
+++ b/src/recensio/plone/profiles/default/registry/settings.xml
@@ -2,5 +2,42 @@
 <registry>
   <records interface="recensio.plone.controlpanel.settings.IRecensioSettings"
            prefix="recensio.plone.settings"
-  />
+  >
+    <record name="recensio.plone.settings.available_content_languages">
+      <value>sq&#13;
+hy&#13;
+az&#13;
+bs&#13;
+bg&#13;
+ca&#13;
+hr&#13;
+cs&#13;
+da&#13;
+nl&#13;
+en&#13;
+et&#13;
+fi&#13;
+fr&#13;
+ka&#13;
+de&#13;
+el&#13;
+hu&#13;
+it&#13;
+la&#13;
+lv&#13;
+lt&#13;
+no&#13;
+pl&#13;
+pt&#13;
+ro&#13;
+ru&#13;
+sr&#13;
+sk&#13;
+sl&#13;
+es&#13;
+sv&#13;
+tr&#13;
+uk</value>
+    </record>
+  </records>
 </registry>

--- a/src/recensio/plone/profiles/default/types/Document.xml
+++ b/src/recensio/plone/profiles/default/types/Document.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Dexterity FTI"
+        name="Document"
+        i18n:domain="plone"
+>
+  <property name="behaviors"
+            purge="false"
+  >
+    <element remove="True"
+             value="plone.versioning"
+    />
+  </property>
+</object>

--- a/src/recensio/plone/profiles/default/types/Event.xml
+++ b/src/recensio/plone/profiles/default/types/Event.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Dexterity FTI"
+        name="Event"
+        i18n:domain="plone"
+>
+  <property name="behaviors"
+            purge="false"
+  >
+    <element remove="True"
+             value="plone.versioning"
+    />
+  </property>
+</object>

--- a/src/recensio/plone/profiles/default/types/Link.xml
+++ b/src/recensio/plone/profiles/default/types/Link.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Dexterity FTI"
+        name="Link"
+        i18n:domain="plone"
+>
+  <property name="behaviors"
+            purge="false"
+  >
+    <element remove="True"
+             value="plone.versioning"
+    />
+  </property>
+</object>

--- a/src/recensio/plone/profiles/default/types/News_Item.xml
+++ b/src/recensio/plone/profiles/default/types/News_Item.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Dexterity FTI"
+        name="News Item"
+        i18n:domain="plone"
+>
+  <property name="behaviors"
+            purge="false"
+  >
+    <element remove="True"
+             value="plone.versioning"
+    />
+  </property>
+</object>

--- a/src/recensio/plone/profiles/default/userschema.xml
+++ b/src/recensio/plone/profiles/default/userschema.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<model xmlns="http://namespaces.plone.org/supermodel/schema"
+       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+       xmlns:users="http://namespaces.plone.org/supermodel/users"
+       i18n:domain="plone"
+>
+  <schema name="member-fields">
+
+    <!-- Standard fields -->
+
+    <field name="home_page"
+           type="zope.schema.URI"
+           users:forms="In User Profile"
+    >
+      <description i18n:translate="help_homepage">
+          The URL for your external home page, if you have one.
+      </description>
+      <required>False</required>
+      <title i18n:translate="label_homepage">Home page</title>
+    </field>
+
+    <field name="description"
+           type="zope.schema.Text"
+           users:forms="In User Profile"
+    >
+      <description i18n:translate="help_biography">
+          A short overview of who you are and what you do. Will be displayed on your author page, linked from the items you create.
+      </description>
+      <required>False</required>
+      <title i18n:translate="label_biography">Biography</title>
+    </field>
+
+    <field name="location"
+           type="zope.schema.TextLine"
+           users:forms="In User Profile"
+    >
+      <description i18n:translate="help_location">
+          Your location - either city and country - or in a company setting, where your office is located.
+      </description>
+      <required>False</required>
+      <title i18n:translate="label_location">Location</title>
+    </field>
+
+    <field name="portrait"
+           type="plone.namedfile.field.NamedBlobImage"
+           users:forms="In User Profile"
+    >
+      <description i18n:translate="help_portrait">
+          To add or change the portrait: click the "Browse" button; select a picture of yourself. Recommended image size is 75 pixels wide by 100 pixels tall.
+      </description>
+      <required>False</required>
+      <title i18n:translate="label_portrait">Portrait</title>
+    </field>
+
+
+    <!-- Recensio custom fields -->
+
+    <field name="academic_title"
+           type="zope.schema.TextLine"
+           users:forms="On Registration|In User Profile"
+    >
+      <description>Please add your academic titles here</description>
+      <required>False</required>
+      <title>Academic title</title>
+    </field>
+
+    <field name="firstname"
+           type="zope.schema.TextLine"
+           users:forms="On Registration|In User Profile"
+    >
+      <description />
+      <title>First name</title>
+    </field>
+
+    <field name="lastname"
+           type="zope.schema.TextLine"
+           users:forms="On Registration|In User Profile"
+    >
+      <description />
+      <title>Last name</title>
+    </field>
+
+    <field name="preferred_language"
+           type="zope.schema.Choice"
+           users:forms="On Registration|In User Profile"
+    >
+      <description>What language do you prefer for receiving e-mails from us?</description>
+      <title>Preferred language</title>
+      <vocabulary>recensio.plone.vocabularies.languages.available_user_languages</vocabulary>
+    </field>
+
+    <field name="declaration_of_identity"
+           type="zope.schema.Bool"
+           users:forms="On Registration"
+    >
+      <description>I declare that I am indeed the person identified by the entries above.&lt;br /&gt;Please find more information in our &lt;a href="#"&gt;data protection statement&lt;/a&gt;.</description>
+      <title>Declaration of identity</title>
+    </field>
+  </schema>
+</model>

--- a/src/recensio/plone/subscribers/review.py
+++ b/src/recensio/plone/subscribers/review.py
@@ -14,6 +14,10 @@ import subprocess
 import tempfile
 
 
+DISABLED = os.environ.get("RECENSIO_DISABLE_SUBSCRIBERS", False)
+if DISABLED:
+    DISABLED = DISABLED.lower() in ("true", "1")
+
 # XXX restore me
 # RUN_SHELL_COMMANDS = os.environ.get("RUN_SHELL_COMMANDS", False)
 RUN_SHELL_COMMANDS = True
@@ -379,6 +383,10 @@ class ReviewPDF:
 def review_pdf_updated_eventhandler(obj, evt):
     """Re-generate the pdf version of the review, then update the cover image
     of the pdf if necessary."""
+
+    if DISABLED:
+        # Don't run subscribers if disabled, e.g. while migrating
+        return
 
     # Re-generate the pdf
     update_generated_pdf(obj)

--- a/src/recensio/plone/subscribers/review.py
+++ b/src/recensio/plone/subscribers/review.py
@@ -278,7 +278,7 @@ def _getAllPageImages(context, size=(320, 452)):
     review_view = api.content.get_view(name="review_view", context=context)
     pdf = review_view.get_review_pdf()
     if pdf:
-        with pdf["blob"].open() as f:
+        with pdf.open() as f:
             pdf_data = f.read()
     if not pdf or not pdf_data:
         return "%s has no pdf" % (context.absolute_url()), None

--- a/src/recensio/plone/subscribers/review.py
+++ b/src/recensio/plone/subscribers/review.py
@@ -379,9 +379,9 @@ class ReviewPDF:
 def review_pdf_updated_eventhandler(obj, evt):
     """Re-generate the pdf version of the review, then update the cover image
     of the pdf if necessary."""
-    if not obj.REQUEST.get("pdf_file"):
-        update_generated_pdf(obj)
 
-    # Terrible hack, if this method gets called without a real
-    # object, we assume that the caller wants htis to happen now
+    # Re-generate the pdf
+    update_generated_pdf(obj)
+
+    # Update the cover image
     ReviewPDF(obj).generatePageImages(later=evt is not None)

--- a/src/recensio/plone/subscribers/simple_publication_workflow.py
+++ b/src/recensio/plone/subscribers/simple_publication_workflow.py
@@ -4,13 +4,25 @@ from plone import api
 from recensio.plone import _
 from recensio.plone.controlpanel.settings import IRecensioSettings
 
+import os
+
 
 logger = getLogger(__name__)
+
+
+DISABLED = os.environ.get("RECENSIO_DISABLE_SUBSCRIBERS", False)
+if DISABLED:
+    DISABLED = DISABLED.lower() in ("true", "1")
 
 
 def mail_after_publication(obj, event):
     """Send an email if the workflow of the obj is simple publication workflow
     and the object is published."""
+
+    if DISABLED:
+        # Don't run subscribers if disabled, e.g. while migrating
+        return
+
     wf = api.portal.get_tool("portal_workflow")
 
     if wf.getChainFor(obj)[0] != "simple_publication_workflow":

--- a/src/recensio/plone/vocabularies/configure.zcml
+++ b/src/recensio/plone/vocabularies/configure.zcml
@@ -20,4 +20,14 @@
            z3c.form.interfaces.IWidget"
       />
 
+  <utility
+      name="recensio.plone.vocabularies.languages.available_user_languages"
+      component=".languages.AvailableUserLanguagesFactory"
+      />
+
+  <utility
+      name="recensio.plone.vocabularies.available_content_languages"
+      component=".languages.AvailableContentLanguagesFactory"
+      />
+
 </configure>

--- a/src/recensio/plone/vocabularies/languages.py
+++ b/src/recensio/plone/vocabularies/languages.py
@@ -1,0 +1,63 @@
+from plone.i18n.locales.interfaces import ILanguageAvailability
+from plone.registry.interfaces import IRegistry
+from Products.CMFCore.utils import getToolByName
+from recensio.plone import _
+from recensio.plone.controlpanel.settings import IRecensioSettings
+from zope.component import getGlobalSiteManager
+from zope.component import queryUtility
+from zope.component.hooks import getSite
+from zope.interface import implementer
+from zope.schema.interfaces import IVocabularyFactory
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
+
+
+@implementer(IVocabularyFactory)
+class AvailableUserLanguages:
+    """Vocabulary that shows all languages that a user might chose during
+    registration."""
+
+    def __call__(self, context):
+        context = getattr(self, "context", getSite())
+        language_tool = getToolByName(context, "portal_languages")
+
+        info = language_tool.getAvailableLanguageInformation()
+        terms = [SimpleTerm(lang, lang, info.get(lang).get("native")) for lang in info]
+        return SimpleVocabulary(terms)
+
+
+AvailableUserLanguagesFactory = AvailableUserLanguages()
+
+
+@implementer(IVocabularyFactory)
+class AvailableContentLanguages:
+    """Vocabulary that holds the languages defined in the recensio-settings and
+    which our content types support."""
+
+    def __call__(self, context):
+        # get user-defined languages
+        registry = queryUtility(IRegistry)
+        settings = registry.forInterface(
+            IRecensioSettings, prefix="recensio.plone.settings"
+        )
+        allowed_langs = (
+            getattr(settings, "available_content_languages", "")
+            .replace("\r", "")
+            .split("\n")
+        )
+        # get names for language codes
+        gsm = getGlobalSiteManager()
+        util = gsm.queryUtility(ILanguageAvailability)
+        available_languages = util.getLanguages()
+        terms = []
+        for lang in allowed_langs:
+            lang = lang.strip()
+            if available_languages.get(lang):
+                terms.append(
+                    SimpleTerm(lang, lang, _(available_languages[lang]["name"]))
+                )
+
+        return SimpleVocabulary(terms)
+
+
+AvailableContentLanguagesFactory = AvailableContentLanguages()


### PR DESCRIPTION
Work for migration and others.
Please check individual commits.

Note: for an import you need to depend on collective.exportimport
also, for an import I used these branches:
https://github.com/plone/plone.restapi/tree/thet-fixes
https://github.com/collective/collective.exportimport/tree/thet-fixes

This was the import command I was using for the import:
```
COLLECTIVE_EXPORTIMPORT_BLOB_HOME=/home/_thet/data/dev/syslab/REPOS/recensio/recensio.buildout/var/blobstorage RECENSIO_DISABLE_SUBSCRIBERS=true ./bin/instance fg
```