### PR TITLE
Sort fields into correct fieldsets and improve order

### DIFF
--- a/src/recensio/plone/behaviors/article.py
+++ b/src/recensio/plone/behaviors/article.py
@@ -11,11 +11,6 @@ from zope.interface import provider
 
 @provider(IFormFieldProvider)
 class IArticle(model.Schema):
-    translatedTitle = schema.TextLine(
-        title=_("Translated Title"),
-        required=False,
-    )
-
     url_article = schema.TextLine(
         title=_("URL (Aufsatz)"),
         required=False,
@@ -31,6 +26,20 @@ class IArticle(model.Schema):
         required=False,
     )
 
+    directives.order_after(subtitle="IBase.title")
+    subtitle = schema.TextLine(
+        title=_("Subtitle"),
+        required=False,
+    )
+    directives.order_after(translatedTitle="IArticle.subtitle")
+    translatedTitle = schema.TextLine(
+        title=_("Translated Title"),
+        required=False,
+    )
+
+    directives.order_after(
+        heading__page_number_of_article_in_journal_or_edited_volume="IArticle.translatedTitle"
+    )
     heading__page_number_of_article_in_journal_or_edited_volume = schema.TextLine(
         title=_(
             "description_page_number_of_article_in_journal_or_edited_volume",
@@ -45,11 +54,15 @@ class IArticle(model.Schema):
         heading__page_number_of_article_in_journal_or_edited_volume="display"
     )
 
+    directives.order_after(
+        pageStartOfArticle="IArticle.heading__page_number_of_article_in_journal_or_edited_volume"
+    )
     pageStartOfArticle = schema.Int(
         title=_("label_page_start_of_article_in_journal_or_edited_volume"),
         required=False,
     )
 
+    directives.order_after(pageEndOfArticle="IArticle.pageStartOfArticle")
     pageEndOfArticle = schema.Int(
         title=_("label_page_end_of_article_in_journal_or_edited_volume"),
         required=False,
@@ -57,10 +70,11 @@ class IArticle(model.Schema):
 
     fieldset_reviewed_text(
         [
-            "translatedTitle",
             "url_article",
             "urn_article",
             "doi_article",
+            "subtitle",
+            "translatedTitle",
             "heading__page_number_of_article_in_journal_or_edited_volume",
             "pageStartOfArticle",
             "pageEndOfArticle",

--- a/src/recensio/plone/behaviors/authors.py
+++ b/src/recensio/plone/behaviors/authors.py
@@ -20,6 +20,7 @@ class IAuthors(model.Schema):
         RelatedItemsFieldWidget,
         pattern_options={"mode": "auto", "favorites": []},
     )
+    directives.order_after(authors="IEditorial.help_authors_or_editors")
     authors = RelationList(
         title=_("Authors"),
         defaultFactory=list,

--- a/src/recensio/plone/behaviors/base_review.py
+++ b/src/recensio/plone/behaviors/base_review.py
@@ -42,6 +42,7 @@ def generateDoi(context):
 
 @provider(IFormFieldProvider)
 class IBaseReview(model.Schema):
+    directives.order_after(pdf="IBase.languageReview")
     pdf = NamedBlobFile(
         title=_("PDF"),
         required=False,
@@ -50,11 +51,28 @@ class IBaseReview(model.Schema):
     directives.no_omit(IAddForm, "pdf")
     directives.no_omit(IEditForm, "pdf")
 
+    directives.order_after(pageStart="IBaseReview.pdf")
+    pageStart = schema.Int(
+        title=_("label_page_start_in_pdf", default="Page number (start)"),
+        description=_(
+            "description_page_number",
+            default="Please fill in only if the review is part of a larger pdf-file",
+        ),
+        required=False,
+    )
+    directives.order_after(pageEnd="IBaseReview.pageStart")
+    pageEnd = schema.Int(
+        title=_("label_page_end_in_pdf", default="Page number (end)"),
+        required=False,
+    )
+
+    directives.order_after(doc="IPagesOfReviewInJournal.pageEndOfReviewInJournal")
     doc = NamedBlobFile(
         title=_("Word Document"),
         required=False,
     )
 
+    directives.order_after(customCitation="IBase.review")
     customCitation = schema.Text(
         title=_("Optional citation format"),
         description=_(
@@ -68,6 +86,7 @@ class IBaseReview(model.Schema):
     )
 
     # XXX: Might need a custom widget to show the proposed DOI
+    directives.order_after(doi="ILicence.licence")
     doi = schema.TextLine(
         title=_("label_doi", default=("DOI")),
         description=_(
@@ -81,6 +100,7 @@ class IBaseReview(model.Schema):
         defaultFactory=generateDoi,
     )
 
+    directives.order_after(customCoverImage="IBaseReview.doi")
     customCoverImage = NamedBlobImage(
         title=_("Custom cover image"),
         description=_(
@@ -95,6 +115,8 @@ class IBaseReview(model.Schema):
     fieldset_review(
         [
             "pdf",
+            "pageStart",
+            "pageEnd",
             "doc",
             "customCitation",
             "doi",
@@ -117,6 +139,22 @@ class BaseReview:
     @pdf.setter
     def pdf(self, value):
         self.context.pdf = value
+
+    @property
+    def pageStart(self):
+        return self.context.pageStart
+
+    @pageStart.setter
+    def pageStart(self, value):
+        self.context.pageStart = value
+
+    @property
+    def pageEnd(self):
+        return self.context.pageEnd
+
+    @pageEnd.setter
+    def pageEnd(self, value):
+        self.context.pageEnd = value
 
     @property
     def doc(self):

--- a/src/recensio/plone/behaviors/configure.zcml
+++ b/src/recensio/plone/behaviors/configure.zcml
@@ -20,6 +20,14 @@
       />
 
   <plone:behavior
+      name="recensio.cover_picture_edited_volume"
+      title="Cover Picture Behavior - variant for edited volumes"
+      factory=".cover_picture.CoverPicture"
+      provides=".cover_picture.ICoverPictureEditedVolume"
+      for="plone.dexterity.interfaces.IDexterityContent"
+      />
+
+  <plone:behavior
       name="recensio.reference_authors"
       title="Reference Authors Behavior"
       factory=".reference_authors.ReferenceAuthors"
@@ -52,10 +60,26 @@
       />
 
   <plone:behavior
+      name="recensio.editorial_edited_volume"
+      title="Editorial Behavior - variant for edited volumes"
+      factory=".editorial.Editorial"
+      provides=".editorial.IEditorialEditedVolume"
+      for="plone.dexterity.interfaces.IDexterityContent"
+      />
+
+  <plone:behavior
       name="recensio.serial"
       title="Serial Behavior"
       factory=".serial.Serial"
       provides=".serial.ISerial"
+      for="plone.dexterity.interfaces.IDexterityContent"
+      />
+
+  <plone:behavior
+      name="recensio.serial_edited_volume"
+      title="Serial Behavior - variant for edited volumes"
+      factory=".serial.Serial"
+      provides=".serial.ISerialEditedVolume"
       for="plone.dexterity.interfaces.IDexterityContent"
       />
 
@@ -76,6 +100,14 @@
       />
 
   <plone:behavior
+      name="recensio.printed_review_edited_volume"
+      title="Printed Review Behavior - variant for edited volumes"
+      factory=".printed_review.PrintedReview"
+      provides=".printed_review.IPrintedReviewEditedVolume"
+      for="plone.dexterity.interfaces.IDexterityContent"
+      />
+
+  <plone:behavior
       name="recensio.base_review"
       title="Base Review Behavior"
       factory=".base_review.BaseReview"
@@ -85,9 +117,17 @@
 
   <plone:behavior
       name="recensio.book_review"
-      title="Printed Review Behavior"
+      title="Book Review Behavior"
       factory=".book_review.BookReview"
       provides=".book_review.IBookReview"
+      for="plone.dexterity.interfaces.IDexterityContent"
+      />
+
+  <plone:behavior
+      name="recensio.edited_volume"
+      title="Edited Volume Review Behavior"
+      factory=".book_review.BookReview"
+      provides=".book_review.IEditedVolume"
       for="plone.dexterity.interfaces.IDexterityContent"
       />
 
@@ -96,6 +136,14 @@
       title="Journal Review Behavior"
       factory=".journal_review.JournalReview"
       provides=".journal_review.IJournalReview"
+      for="plone.dexterity.interfaces.IDexterityContent"
+      />
+
+  <plone:behavior
+      name="recensio.journal_article_review"
+      title="Journal Article Review Behavior"
+      factory=".journal_review.JournalReview"
+      provides=".journal_review.IJournalArticleReview"
       for="plone.dexterity.interfaces.IDexterityContent"
       />
 
@@ -112,6 +160,14 @@
       title="Recensio base behavior"
       factory=".base.Base"
       provides=".base.IBase"
+      for="plone.dexterity.interfaces.IDexterityContent"
+      />
+
+  <plone:behavior
+      name="recensio.base_exhibition"
+      title="Recensio base exhibition behavior"
+      factory=".base.Base"
+      provides=".base.IBaseExhibition"
       for="plone.dexterity.interfaces.IDexterityContent"
       />
 

--- a/src/recensio/plone/behaviors/cover_picture.py
+++ b/src/recensio/plone/behaviors/cover_picture.py
@@ -1,8 +1,10 @@
+from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.namedfile.field import NamedBlobImage
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_edited_volume
 from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from zope.component import adapter
 from zope.interface import provider
@@ -14,8 +16,18 @@ class ICoverPicture(model.Schema):
         title=_("Cover picture"),
         required=False,
     )
-
+    directives.order_after(coverPicture="IPrintedReview.placeOfPublication")
     fieldset_reviewed_text(["coverPicture"])
+
+
+@provider(IFormFieldProvider)
+class ICoverPictureEditedVolume(model.Schema):
+    coverPicture = NamedBlobImage(
+        title=_("Cover picture"),
+        required=False,
+    )
+    directives.order_after(coverPicture="IPrintedReviewEditedVolume.publisherOnline")
+    fieldset_edited_volume(["coverPicture"])
 
 
 @adapter(IDexterityContent)

--- a/src/recensio/plone/behaviors/directives.py
+++ b/src/recensio/plone/behaviors/directives.py
@@ -32,5 +32,15 @@ class fieldset_review(fieldset):
 
 
 class fieldset_exhibition(fieldset):
-    id = ("exhibition",)
-    label = (_("label_schema_exhibition", default="Ausstellung"),)
+    id = "exhibition"
+    label = _("label_schema_exhibition", default="Ausstellung")
+
+
+class fieldset_article(fieldset):
+    id = "article"
+    label = _("label_schema_article", default="Aufsatz")
+
+
+class fieldset_edited_volume(fieldset):
+    id = "edited_volume"
+    label = _("label_schema_collection", default="Sammelband / Zeitschrift")

--- a/src/recensio/plone/behaviors/journal_review.py
+++ b/src/recensio/plone/behaviors/journal_review.py
@@ -1,7 +1,9 @@
+from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_edited_volume
 from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from zope import schema
 from zope.component import adapter
@@ -43,6 +45,7 @@ class IJournalReview(model.Schema):
         required=False,
     )
 
+    directives.order_after(shortnameJournal="IReviewJournal.translatedTitleJournal")
     shortnameJournal = schema.TextLine(
         title=_("Shortname"),
         required=False,
@@ -62,8 +65,92 @@ class IJournalReview(model.Schema):
         title=_("Official year of publication (if different)"),
         required=False,
     )
-
+    # customizations
+    directives.order_before(issn="IBase.languageReviewedText")
+    directives.order_before(issn_online="IBase.languageReviewedText")
+    directives.order_before(url_journal="IBase.languageReviewedText")
+    directives.order_before(urn_journal="IBase.languageReviewedText")
+    directives.order_before(doi_journal="IBase.languageReviewedText")
+    directives.order_after(officialYearOfPublication="IPrintedReview.yearOfPublication")
     fieldset_reviewed_text(
+        [
+            "issn",
+            "issn_online",
+            "url_journal",
+            "urn_journal",
+            "doi_journal",
+            "shortnameJournal",
+            "volumeNumber",
+            "issueNumber",
+            "officialYearOfPublication",
+        ],
+    )
+
+
+@provider(IFormFieldProvider)
+class IJournalArticleReview(model.Schema):
+    issn = schema.TextLine(
+        title=_("ISSN"),
+        description=_(
+            "description_issn",
+            default=("With or without hyphens."),
+        ),
+        required=False,
+    )
+
+    issn_online = schema.TextLine(
+        title=_("ISSN Online"),
+        description=_(
+            "description_issn_online",
+            default=("With or without hyphens."),
+        ),
+        required=False,
+    )
+
+    url_journal = schema.TextLine(
+        title=_("URL (Zeitschrift)"),
+        required=False,
+    )
+
+    urn_journal = schema.TextLine(
+        title=_("URN (Zeitschrift)"),
+        required=False,
+    )
+
+    doi_journal = schema.TextLine(
+        title=_("DOI (Zeitschrift)"),
+        required=False,
+    )
+
+    directives.order_after(shortnameJournal="IReviewJournal.translatedTitleJournal")
+    shortnameJournal = schema.TextLine(
+        title=_("Shortname"),
+        required=False,
+    )
+
+    volumeNumber = schema.TextLine(
+        title=_("Vol."),
+        required=False,
+    )
+
+    issueNumber = schema.TextLine(
+        title=_("Number"),
+        required=False,
+    )
+
+    officialYearOfPublication = schema.TextLine(
+        title=_("Official year of publication (if different)"),
+        required=False,
+    )
+    # customizations
+    directives.order_after(
+        officialYearOfPublication="IPrintedReviewEditedVolume.yearOfPublication"
+    )
+    directives.order_after(
+        volumeNumber="IJournalArticleReview.officialYearOfPublication"
+    )
+    directives.order_after(issueNumber="IJournalArticleReview.volumeNumber")
+    fieldset_edited_volume(
         [
             "issn",
             "issn_online",

--- a/src/recensio/plone/behaviors/licence.py
+++ b/src/recensio/plone/behaviors/licence.py
@@ -5,6 +5,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_review
 from z3c.relationfield.schema import RelationChoice
 from zope import schema
 from zope.component import adapter
@@ -15,6 +16,7 @@ from zope.interface import provider
 class ILicence(model.Schema):
     # TODO
     # rows=3,
+    directives.order_after(licence="IBase.ppn")
     licence = schema.Text(
         title=_("label_publication_licence", default="Publication Licence"),
         description=_(
@@ -34,6 +36,7 @@ class ILicence(model.Schema):
         RelatedItemsFieldWidget,
         pattern_options={"mode": "auto", "favorites": []},
     )
+    directives.order_after(licence_ref="ISettingsURLInCitation.URLShownInCitationNote")
     licence_ref = RelationChoice(
         title=_(
             "label_publication_licence_ref",
@@ -51,6 +54,7 @@ class ILicence(model.Schema):
         source=CatalogSource(portal_type="Document"),
         required=False,
     )
+    fieldset_review(["licence", "licence_ref"])
 
 
 @adapter(IDexterityContent)

--- a/src/recensio/plone/behaviors/pages_of_review_in_journal.py
+++ b/src/recensio/plone/behaviors/pages_of_review_in_journal.py
@@ -1,3 +1,4 @@
+from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
@@ -10,9 +11,13 @@ from zope.interface import provider
 
 @provider(IFormFieldProvider)
 class IPagesOfReviewInJournal(model.Schema):
+    directives.order_after(pageStartOfReviewInJournal="IBaseReview.pageEnd")
     pageStartOfReviewInJournal = schema.Int(
         title=_("label_page_start_of_review_in_journal", default="First page"),
         required=False,
+    )
+    directives.order_after(
+        pageEndOfReviewInJournal="IPagesOfReviewInJournal.pageStartOfReviewInJournal"
     )
     pageEndOfReviewInJournal = schema.Int(
         title=_("label_page_end_of_review_in_journal", default="Last page"),

--- a/src/recensio/plone/behaviors/printed_review.py
+++ b/src/recensio/plone/behaviors/printed_review.py
@@ -4,6 +4,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_edited_volume
 from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from zope import schema
 from zope.component import adapter
@@ -12,16 +13,12 @@ from zope.interface import provider
 
 @provider(IFormFieldProvider)
 class IPrintedReview(model.Schema):
-    heading_presented_work = schema.TextLine(
-        title=_("heading_presented_work", default=("Information on presented work")),
-        required=False,
-    )
-    directives.mode(heading_presented_work="display")
-
-    subtitle = schema.TextLine(
-        title=_("Subtitle"),
-        required=False,
-    )
+    # XXX Only needed if and when we implement presentations
+    # heading_presented_work = schema.TextLine(
+    #    title=_("heading_presented_work", default=("Information on presented work")),
+    #    required=False,
+    # )
+    # directives.mode(heading_presented_work="display")
 
     yearOfPublication = schema.TextLine(
         title=_("Year of publication"),
@@ -60,11 +57,18 @@ class IPrintedReview(model.Schema):
         required=False,
     )
     directives.omitted("idBvb")
-
+    # customizations
+    directives.order_after(yearOfPublication="IJournalReview.shortnameJournal")
+    directives.order_after(placeOfPublication="IJournalReview.issueNumber")
+    directives.order_after(publisher="IPrintedReview.placeOfPublication")
+    directives.order_after(yearOfPublicationOnline="IPrintedReview.publisher")
+    directives.order_after(
+        placeOfPublicationOnline="IPrintedReview.yearOfPublicationOnline"
+    )
+    directives.order_after(publisherOnline="IPrintedReview.placeOfPublicationOnline")
     fieldset_reviewed_text(
         [
-            "heading_presented_work",
-            "subtitle",
+            # "heading_presented_work",
             "yearOfPublication",
             "placeOfPublication",
             "publisher",
@@ -73,6 +77,81 @@ class IPrintedReview(model.Schema):
             "publisherOnline",
             "idBvb",
         ],
+    )
+
+
+@provider(IFormFieldProvider)
+class IPrintedReviewEditedVolume(model.Schema):
+    # XXX Only needed if and when we implement presentations
+    # heading_presented_work = schema.TextLine(
+    #    title=_("heading_presented_work", default=("Information on presented work")),
+    #    required=False,
+    # )
+    # directives.mode(heading_presented_work="display")
+
+    yearOfPublication = schema.TextLine(
+        title=_("Year of publication"),
+        required=False,
+    )
+
+    placeOfPublication = schema.TextLine(
+        title=_("Place of publication"),
+        required=False,
+    )
+
+    publisher = schema.TextLine(
+        title=_("Publisher"),
+        required=False,
+    )
+    textindexer.searchable("publisher")
+
+    yearOfPublicationOnline = schema.TextLine(
+        title=_("Year of publication (Online)"),
+        required=False,
+    )
+
+    placeOfPublicationOnline = schema.TextLine(
+        title=_("Place of publication (Online)"),
+        required=False,
+    )
+
+    publisherOnline = schema.TextLine(
+        title=_("Publisher (Online)"),
+        required=False,
+    )
+    textindexer.searchable("publisherOnline")
+
+    idBvb = schema.TextLine(
+        title="idBvb",
+        required=False,
+    )
+    directives.omitted("idBvb")
+    # customizations
+    directives.order_after(yearOfPublication="IJournalArticleReview.shortnameJournal")
+    directives.order_after(
+        placeOfPublication="IPrintedReviewEditedVolume.yearOfPublication"
+    )
+    directives.order_after(publisher="IPrintedReviewEditedVolume.placeOfPublication")
+    directives.order_after(
+        yearOfPublicationOnline="IPrintedReviewEditedVolume.publisher"
+    )
+    directives.order_after(
+        placeOfPublicationOnline="IPrintedReviewEditedVolume.yearOfPublicationOnline"
+    )
+    directives.order_after(
+        publisherOnline="IPrintedReviewEditedVolume.placeOfPublicationOnline"
+    )
+    fieldset_edited_volume(
+        [
+            # "heading_presented_work",
+            "yearOfPublication",
+            "placeOfPublication",
+            "publisher",
+            "yearOfPublicationOnline",
+            "placeOfPublicationOnline",
+            "publisherOnline",
+            "idBvb",
+        ]
     )
 
 
@@ -90,14 +169,6 @@ class PrintedReview:
     @heading_presented_work.setter
     def heading_presented_work(self, value):
         pass
-
-    @property
-    def subtitle(self):
-        return self.context.subtitle
-
-    @subtitle.setter
-    def subtitle(self, value):
-        self.context.subtitle = value
 
     @property
     def yearOfPublication(self):

--- a/src/recensio/plone/behaviors/serial.py
+++ b/src/recensio/plone/behaviors/serial.py
@@ -1,7 +1,9 @@
+from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_edited_volume
 from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from zope import schema
 from zope.component import adapter
@@ -10,22 +12,48 @@ from zope.interface import provider
 
 @provider(IFormFieldProvider)
 class ISerial(model.Schema):
+    directives.order_after(series="IPrintedReview.publisherOnline")
     series = schema.TextLine(
         title=_("Series"),
         required=False,
     )
 
+    directives.order_after(seriesVol="ISerial.series")
     seriesVol = schema.TextLine(
         title=_("Series (vol.)"),
         required=False,
     )
 
+    directives.order_after(pages="ISerial.seriesVol")
     pages = schema.TextLine(
         title=_("Pages"),
         required=False,
     )
-
+    # customizations
     fieldset_reviewed_text(["series", "seriesVol", "pages"])
+
+
+@provider(IFormFieldProvider)
+class ISerialEditedVolume(model.Schema):
+    directives.order_after(series="IPrintedReview.publisherOnline")
+    series = schema.TextLine(
+        title=_("Series"),
+        required=False,
+    )
+
+    directives.order_after(seriesVol="ISerial.series")
+    seriesVol = schema.TextLine(
+        title=_("Series (vol.)"),
+        required=False,
+    )
+
+    directives.order_after(pages="ISerial.seriesVol")
+    pages = schema.TextLine(
+        title=_("Pages"),
+        required=False,
+    )
+    # customizations
+    fieldset_edited_volume(["series", "seriesVol", "pages"])
 
 
 @adapter(IDexterityContent)

--- a/src/recensio/plone/behaviors/settings_url_in_citation.py
+++ b/src/recensio/plone/behaviors/settings_url_in_citation.py
@@ -1,3 +1,4 @@
+from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
@@ -29,6 +30,7 @@ class ISettingsURLInCitation(model.Schema):
     # condition="python:object.aq_parent.isURLShownInCitationNote() if object.aq_parent != object else True",
     # Show only as label, if:
     #     condition="python:not object.aq_parent.isURLShownInCitationNote() if object.aq_parent != object else False",
+    directives.order_after(URLShownInCitationNote="IBaseReview.customCoverImage")
     URLShownInCitationNote = schema.Bool(
         title=_(
             "label_is_url_shown_in_citation_note",

--- a/src/recensio/plone/content/__init__.py
+++ b/src/recensio/plone/content/__init__.py
@@ -1,5 +1,10 @@
 from plone.app.dexterity.behaviors.id import IShortName
+from plone.app.dexterity.behaviors.metadata import ICategorization
 from plone.autoform.interfaces import OMITTED_KEY
+from plone.autoform.interfaces import ORDER_KEY
+from plone.supermodel.interfaces import FIELDSETS_KEY
+from plone.supermodel.model import Fieldset
+from recensio.plone import _
 from z3c.form.interfaces import IAddForm
 from z3c.form.interfaces import IEditForm
 from zope.interface import Interface
@@ -13,3 +18,12 @@ IShortName.setTaggedValue(
         (IEditForm, "id", "false"),
     ],
 )
+
+reviewed_text_categorization = Fieldset(
+    "reviewed_text",
+    label=_("label_schema_reviewed_text", default="Reviewed Text"),
+    fields=["subjects"],
+)
+ICategorization.setTaggedValue(ORDER_KEY, [("subjects", "after", "IBase.ddcPlace")])
+ICategorization.setTaggedValue(FIELDSETS_KEY, [reviewed_text_categorization])
+ICategorization.setTaggedValue(OMITTED_KEY, [(Interface, "language", "true")])

--- a/src/recensio/plone/content/review_article_collection.py
+++ b/src/recensio/plone/content/review_article_collection.py
@@ -1,7 +1,9 @@
+from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.supermodel import model
 from recensio.plone import _
+from recensio.plone.behaviors.directives import fieldset_edited_volume
 from recensio.plone.interfaces import IReview
 from zope import schema
 from zope.interface import implementer
@@ -13,21 +15,28 @@ class IReviewArticleCollection(model.Schema, IReview):
     """Marker interface and Dexterity Python Schema for
     ReviewArticleCollection."""
 
+    directives.order_after(titleEditedVolume="IEditorialEditedVolume.editorial")
     titleEditedVolume = schema.TextLine(
         title=_("title_edited_volume", default="Title (Edited Volume)"),
         required=True,
     )
 
+    directives.order_after(subtitleEditedVolume="titleEditedVolume")
     subtitleEditedVolume = schema.TextLine(
         title=_("subtitle_edited_volume", default="Subtitle (Edited Volume)"),
         required=False,
     )
 
+    directives.order_after(translatedTitleEditedVolume="subtitleEditedVolume")
     # TODO
     # size=60
     translatedTitleEditedVolume = schema.TextLine(
         required=False,
         title=_("Translated title (Edited Volume)"),
+    )
+
+    fieldset_edited_volume(
+        ["titleEditedVolume", "subtitleEditedVolume", "translatedTitleEditedVolume"]
     )
 
 

--- a/src/recensio/plone/content/review_article_journal.py
+++ b/src/recensio/plone/content/review_article_journal.py
@@ -1,8 +1,9 @@
+from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.supermodel import model
 from recensio.plone import _
-from recensio.plone.behaviors.directives import fieldset_reviewed_text
+from recensio.plone.behaviors.directives import fieldset_edited_volume
 from recensio.plone.interfaces import IReview
 from zope import schema
 from zope.interface import implementer
@@ -14,16 +15,19 @@ class IReviewArticleJournal(model.Schema, IReview):
     """Marker interface and Dexterity Python Schema for
     ReviewArticleJournal."""
 
+    directives.order_after(editor="IJournalArticleReview.doi_journal")
     editor = schema.TextLine(
         title=_("Editor (name or institution)"),
         required=False,
     )
 
+    directives.order_after(titleJournal="editor")
     titleJournal = schema.TextLine(
         title=_("title_journal", default="Title (Journal)"),
         required=True,
     )
 
+    directives.order_after(translatedTitleJournal="titleJournal")
     translatedTitleJournal = schema.TextLine(
         title=_(
             "label_translated_title_journal",
@@ -32,7 +36,7 @@ class IReviewArticleJournal(model.Schema, IReview):
         required=False,
     )
 
-    fieldset_reviewed_text(["editor", "translatedTitleJournal"])
+    fieldset_edited_volume(["editor", "titleJournal", "translatedTitleJournal"])
 
 
 # TODO

--- a/src/recensio/plone/content/review_exhibition.py
+++ b/src/recensio/plone/content/review_exhibition.py
@@ -2,12 +2,13 @@ from collective.z3cform.datagridfield.datagridfield import DataGridFieldFactory
 from collective.z3cform.datagridfield.row import DictRow
 from plone.app.vocabularies.catalog import CatalogSource
 from plone.app.z3cform.widget import RelatedItemsFieldWidget
+from plone.autoform import directives
 from plone.autoform.directives import widget
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.supermodel import model
 from recensio.plone import _
-from recensio.plone.behaviors.directives import fieldset_exhibition
+from recensio.plone.behaviors.directives import fieldset_reviewed_text
 from recensio.plone.interfaces import IReview
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
@@ -61,6 +62,7 @@ class IDatesRowSchema(interface.Interface):
 class IReviewExhibition(model.Schema, IReview):
     """Marker interface and Dexterity Python Schema for ReviewExhibition."""
 
+    directives.order_after(subtitle="titleProxy")
     subtitle = schema.TextLine(
         title=_("Subtitle"),
         required=False,
@@ -133,8 +135,9 @@ class IReviewExhibition(model.Schema, IReview):
         required=False,
     )
 
-    fieldset_exhibition(
+    fieldset_reviewed_text(
         [
+            "subtitle",
             "exhibiting_institution",
             "dates",
             "years",
@@ -151,3 +154,11 @@ class IReviewExhibition(model.Schema, IReview):
 @implementer(IReviewExhibition)
 class ReviewExhibition(Item):
     """Content-type class for IReviewExhibition."""
+
+    def _get_title(self):
+        return self.titleProxy or "Ausstellung"
+
+    def _set_title(self, value):
+        self.titleProxy = value
+
+    title = property(_get_title, _set_title)

--- a/src/recensio/plone/content/review_journal.py
+++ b/src/recensio/plone/content/review_journal.py
@@ -1,3 +1,4 @@
+from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.supermodel import model
@@ -13,10 +14,12 @@ from zope.interface import provider
 class IReviewJournal(model.Schema, IReview):
     """Marker interface and Dexterity Python Schema for ReviewJournal."""
 
+    directives.order_after(editor="IBase.languageReviewedText")
     editor = schema.TextLine(
         title=_("Editor (name or institution)"),
     )
 
+    directives.order_after(translatedTitleJournal="IBase.title")
     translatedTitleJournal = schema.TextLine(
         title=_(
             "label_translated_title_journal",

--- a/src/recensio/plone/content/review_monograph.py
+++ b/src/recensio/plone/content/review_monograph.py
@@ -1,3 +1,4 @@
+from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.supermodel import model
@@ -13,6 +14,7 @@ from zope.interface import provider
 class IReviewMonograph(model.Schema, IReview):
     """Marker interface and Dexterity Python Schema for ReviewMonograph."""
 
+    directives.order_after(translatedTitle="IBookReview.additionalTitles")
     translatedTitle = schema.TextLine(
         title=_("Translated Title"),
         required=False,

--- a/src/recensio/plone/profiles/default/types/Review_Article_Collection.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Article_Collection.xml
@@ -29,7 +29,6 @@
 
   <!-- Enabled behaviors -->
   <property name="behaviors">
-    <element value="plone.basic" />
     <element value="plone.categorization" />
     <element value="plone.locking" />
     <element value="plone.namefromtitle" />
@@ -37,12 +36,12 @@
     <element value="recensio.authors" />
     <element value="recensio.base" />
     <element value="recensio.base_review" />
-    <element value="recensio.book_review" />
-    <element value="recensio.cover_picture" />
-    <element value="recensio.editorial" />
+    <element value="recensio.cover_picture_edited_volume" />
+    <element value="recensio.edited_volume" />
+    <element value="recensio.editorial_edited_volume" />
     <element value="recensio.licence" />
-    <element value="recensio.printed_review" />
-    <element value="recensio.serial" />
+    <element value="recensio.printed_review_edited_volume" />
+    <element value="recensio.serial_edited_volume" />
     <element value="recensio.settings_url_in_citation" />
   </property>
 

--- a/src/recensio/plone/profiles/default/types/Review_Article_Journal.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Article_Journal.xml
@@ -36,7 +36,6 @@
 
   <!-- Enabled behaviors -->
   <property name="behaviors">
-    <element value="plone.basic" />
     <element value="plone.categorization" />
     <element value="plone.locking" />
     <element value="plone.namefromtitle" />
@@ -45,8 +44,9 @@
     <element value="recensio.base" />
     <element value="recensio.base_review" />
     <element value="recensio.cover_picture" />
-    <element value="recensio.journal_review" />
+    <element value="recensio.journal_article_review" />
     <element value="recensio.licence" />
+    <element value="recensio.pages_of_review_in_journal" />
     <element value="recensio.printed_review" />
     <element value="recensio.settings_url_in_citation" />
   </property>

--- a/src/recensio/plone/profiles/default/types/Review_Exhibition.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Exhibition.xml
@@ -29,11 +29,10 @@
 
   <!-- Enabled behaviors -->
   <property name="behaviors">
-    <element value="plone.basic" />
     <element value="plone.categorization" />
     <element value="plone.locking" />
     <element value="plone.namefromtitle" />
-    <element value="recensio.base" />
+    <element value="recensio.base_exhibition" />
     <element value="recensio.base_review" />
     <element value="recensio.licence" />
     <element value="recensio.settings_url_in_citation" />

--- a/src/recensio/plone/profiles/default/types/Review_Journal.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Journal.xml
@@ -36,7 +36,6 @@
 
   <!-- Enabled behaviors -->
   <property name="behaviors">
-    <element value="plone.basic" />
     <element value="plone.categorization" />
     <element value="plone.locking" />
     <element value="plone.namefromtitle" />

--- a/src/recensio/plone/profiles/default/types/Review_Monograph.xml
+++ b/src/recensio/plone/profiles/default/types/Review_Monograph.xml
@@ -36,7 +36,6 @@
 
   <!-- Enabled behaviors -->
   <property name="behaviors">
-    <element value="plone.basic" />
     <element value="plone.categorization" />
     <element value="plone.locking" />
     <element value="plone.namefromtitle" />

--- a/src/recensio/plone/utils.py
+++ b/src/recensio/plone/utils.py
@@ -104,7 +104,8 @@ def format_title_and_subtitle(title, subtitle):
 
 
 def punctuated_title_and_subtitle(review):
-    titles = [(review.title, getattr(review, "subtitle", None))]
+    title = getattr(review, "titleProxy", review.title)
+    titles = [(title, getattr(review, "subtitle", None))]
     if getattr(review, "additionalTitles", None):
         titles = titles + [
             (


### PR DESCRIPTION
For the sake of your sanity I don't really expect a full review of this. It's mostly fieldset and order directives. The various content types use different combinations of behaviors but are supposed to have their particular order of fields. That would sometimes lead to conflicting order directives. I tried to avoid code duplication by defining base schema classes and making multiple adapters inherit from the same base, but the system tried to adapt the content to the base schema instead of the behavior schema. So I ended up copying a lot of fields, e.g. from IBookReview to [IEditedVolume](https://github.com/syslabcom/recensio.plone/pull/141/files#diff-a777c9979390e3eba792e9394294fd776de32bd5482b658aa101735204e50c65R99). (Maybe behaviors were not the most fitting solution in the first place, but we don't have the budget to rework this now.)

One thing worth mentioning is that I removed the `plone.basic` behavior and instead [added a `title` field to the `recensio.base` behavior](https://github.com/syslabcom/recensio.plone/pull/141/files#diff-34df83e1f60c8f0e1821e126a5d23565c810ccfcac0f09633d9db7d79df356f7R44). `plone.basic` also has a `description` field and some fieldset and order directives that we don't want, so it seemed cleaner to me this way. However, `Review Exhibition` does not have a regular title, because some exhibitions don't have a title. I included some fixes to the `titleProxy` field to make this work ([`title` returns `titleProxy` or “Ausstellung”](https://github.com/syslabcom/recensio.plone/pull/141/files#diff-f8c7f5c8e2f586b75ebb68d0d6159a0c81f73241aee7e72c975de90b4839d41cR158), [`punctuated_title_and_subtitle` uses `titleProxy` if it exists](https://github.com/syslabcom/recensio.plone/pull/141/files#diff-12e75a9a7a67cf75ffcac95582773fb3a8695b84043e9700c058a3740d48c025R107).

I also added a few fields that I noticed were missing, like `pageStart` and `pageEnd`.

syslabcom/scrum#1199