### PR TITLE
Author Search: Implement alphabet index with a path search

### DIFF
--- a/src/recensio/plone/browser/authorsearch.py
+++ b/src/recensio/plone/browser/authorsearch.py
@@ -39,6 +39,7 @@ class AuthorSearchView(BrowserView, CrossPlatformMixin):
     def authors(self):
         catalog = getToolByName(self.context, "portal_catalog")
         author_string = safe_unicode(self.request.get("authors"))
+        letter = safe_unicode(self.request.get("letter"))
         b_start = int(self.request.get("b_start", 0))
         b_size = int(self.request.get("b_size", 30))
         query = {
@@ -53,6 +54,10 @@ class AuthorSearchView(BrowserView, CrossPlatformMixin):
             query["path"] = navigation_root
         if author_string:
             query["SearchableText"] = author_string.strip("\"'")
+        if letter and letter in self.ALPHABET:
+            # XXX conflicts with navigation root
+            context_path = "/".join(self.context.getPhysicalPath())
+            query["path"] = f"{context_path}/gnd/{letter.lower()}"
         return catalog(query)
 
     @property

--- a/src/recensio/plone/browser/templates/authorsearch.pt
+++ b/src/recensio/plone/browser/templates/authorsearch.pt
@@ -60,7 +60,9 @@
            "
       >
 
-        <form class="crossportalsearchform">
+        <form class="crossportalsearchform"
+              tal:condition="python:False"
+        >
           <input ;=""
                  name="authors"
                  type="hidden"
@@ -112,7 +114,7 @@
             <a href="#"
                tal:content="letter"
                tal:attributes="
-                 href python:request.getURL() + '?authors=' + letter + '*&use_navigation_root:boolean=' + str(request.get('use_navigation_root', True));
+                 href python:request.getURL() + '?letter=' + letter + '&use_navigation_root:boolean=' + str(request.get('use_navigation_root', True));
                "
             ></a>
           </tal:block>


### PR DESCRIPTION
This way authors are listed by their last name.

The cross portal search is also deactivated; see ticket.

syslabcom/scrum#2015