### PR TITLE
Search: restrict to specific types.

### DIFF
--- a/src/recensio/plone/profiles/default/registry/search.xml
+++ b/src/recensio/plone/profiles/default/registry/search.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<registry>
+  <record name="plone.types_not_searched">
+    <value>
+      <element>Collection</element>
+      <element>Discussion Item</element>
+      <element>Document</element>
+      <element>Event</element>
+      <element>File</element>
+      <element>Folder</element>
+      <element>Image</element>
+      <element>Link</element>
+      <element>News Item</element>
+      <element>Person</element>
+      <element>Plone Site</element>
+      <element>Presentation Article Review</element>
+      <element>Presentation Collection</element>
+      <element>Presentation Monograph</element>
+      <element>Presentation Online Resource</element>
+      <element>Publication</element>
+      <element>TempFolder</element>
+      <element>Topic</element>
+    </value>
+  </record>
+</registry>

--- a/src/recensio/plone/upgrades/v1/20240506162555_update_search_settings/registry.xml
+++ b/src/recensio/plone/upgrades/v1/20240506162555_update_search_settings/registry.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<registry>
+  <record name="plone.types_not_searched">
+    <value purge="False">
+      <element>Collection</element>
+      <element>Document</element>
+      <element>Event</element>
+      <element>File</element>
+      <element>Folder</element>
+      <element>Image</element>
+      <element>Link</element>
+      <element>News Item</element>
+      <element>Person</element>
+      <element>Presentation Article Review</element>
+      <element>Presentation Collection</element>
+      <element>Presentation Monograph</element>
+      <element>Presentation Online Resource</element>
+      <element>Publication</element>
+      <element>Topic</element>
+    </value>
+  </record>
+</registry>

--- a/src/recensio/plone/upgrades/v1/20240506162555_update_search_settings/upgrade.py
+++ b/src/recensio/plone/upgrades/v1/20240506162555_update_search_settings/upgrade.py
@@ -1,0 +1,8 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdateSearchSettings(UpgradeStep):
+    """Update search settings."""
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Ref: [scrum-2227](https://github.com/syslabcom/scrum/issues/2227)

With this PR, issue.pdf cannot be found anymore.

However, even "Volumes" are not searched. Also the "Über uns" section is also not searched.

IMO we should loosen the search restrictions a bit, but if this is what the customer wants, here you go.
