### PR TITLE
Avoid computing `listAuthorsAndEditors` twice

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.0.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Avoid computing ``listAuthorsAndEditors`` twice
+  `#3678 <https://github.com/syslabcom/scrum/issues/3678>`_
 
 
 1.0.6 (2025-05-22)

--- a/src/recensio/plone/viewlets/viewlets.py
+++ b/src/recensio/plone/viewlets/viewlets.py
@@ -136,8 +136,10 @@ class Publicationlisting(ViewletBase):
                 {"portal_type": ["Review Monograph", "Review Journal"]},
                 full_objects=True,
             )
-        review_objs = sorted(review_objs, key=lambda v: listAuthorsAndEditors(v)())
         reviews = [self._make_dict(rev) for rev in review_objs]
+        reviews = sorted(
+            reviews, key=lambda r: r["listAuthorsAndEditors"], reverse=True
+        )
         return reviews
 
     def _formatsize(self, size):


### PR DESCRIPTION
Refs. https://github.com/syslabcom/scrum/issues/3678