### PR TITLE
Cleanup eea.facetednavigation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 
 - Nothing changed yet.
 
+- Cleanup eea.facetednavigation, now that we have solr.
+  [pilz]
 
 2.1.1 (2026-04-05)
 ------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -60,10 +60,6 @@ collective.vdexvocabulary = 0.3
 collective.z3cform.datagridfield = 3.0.4
 
 # Required by:
-# recensio.plone==2.0.0.dev0
-eea.facetednavigation = 16.4
-
-# Required by:
 # kitconcept.recipe.solr==1.0.0a5
 hexagonit.recipe.download = 1.7.1
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         "setuptools",
         "beautifulsoup4",
         "collective.solr>=10.1.1",
-        "eea.facetednavigation",
         "collective.ftw.upgrade",
         "guess-language>=1.0.0",
         "plone.api",

--- a/src/recensio/plone/browser/configure.zcml
+++ b/src/recensio/plone/browser/configure.zcml
@@ -1,14 +1,8 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
-    xmlns:faceted="http://namespaces.zope.org/faceted"
     xmlns:plone="http://namespaces.plone.org/plone"
     >
-
-  <include
-      package="eea.facetednavigation"
-      file="meta.zcml"
-      />
 
   <browser:resourceDirectory
       name="recensio.theme.bundles"
@@ -124,17 +118,6 @@
 
   <!-- Listing views -->
 
-  <configure package="eea.facetednavigation.browser">
-    <browser:page
-        name="faceted_query"
-        for="..interfaces.IFacetedNavigable"
-        class="recensio.plone.browser.listing.RecensioFacetedQueryHandler"
-        template="template/query.pt"
-        permission="zope2.View"
-        layer="recensio.plone.interfaces.IRecensioPloneLayer"
-        />
-  </configure>
-
   <browser:page
       name="sorting-menu"
       for="*"
@@ -143,9 +126,8 @@
       permission="zope2.View"
       />
 
-  <faceted:view
+  <browser:page
       name="results-listing"
-      title="Review Results Listing"
       for="*"
       class=".listing.ResultsListing"
       template="templates/results-listing.pt"

--- a/src/recensio/plone/browser/listing.py
+++ b/src/recensio/plone/browser/listing.py
@@ -1,5 +1,4 @@
 from collective.solr.browser.facets import SearchView
-from eea.facetednavigation.browser.app.query import FacetedQueryHandler
 from plone import api
 from plone.app.contentlisting.interfaces import IContentListing
 from plone.base.navigationroot import get_navigation_root
@@ -58,16 +57,6 @@ class ListingBase(BrowserView):
             msgid=msgid,
             context=self.request,
         )
-
-
-class RecensioFacetedQueryHandler(FacetedQueryHandler, ListingBase):
-    """Add recensio capabilities"""
-
-    def criteria(self, **kwargs):
-        """Don't restrict language"""
-        criteria = super().criteria(**kwargs)
-        del criteria["Language"]
-        return criteria
 
 
 class RecensioSearch(SearchView, ListingBase):


### PR DESCRIPTION
This PR also requires eea.facetednavigation to be removed from buildout and the removal of objects from the database. tbc.